### PR TITLE
Fix bridge deployment runtime and scope service workflows

### DIFF
--- a/.github/workflows/deploy-auth.yml
+++ b/.github/workflows/deploy-auth.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "auth-service/**"
+      - ".github/workflows/deploy-auth.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/deploy-bridge.yml
+++ b/.github/workflows/deploy-bridge.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "bridge-service/**"
+      - "shared/token-registry.json"
+      - ".github/workflows/deploy-bridge.yml"
   workflow_dispatch:
 
 permissions:
@@ -46,7 +50,9 @@ jobs:
           IMAGE_LATEST: ${{ env.IMAGE_REPO }}:latest
         run: |
           set -euo pipefail
-          docker build -t "$IMAGE_SHA" -t "$IMAGE_LATEST" ./bridge-service
+          mkdir -p bridge-service/shared
+          cp shared/token-registry.json bridge-service/shared/token-registry.json
+          docker build --target production -t "$IMAGE_SHA" -t "$IMAGE_LATEST" ./bridge-service
           docker push "$IMAGE_SHA"
           docker push "$IMAGE_LATEST"
 

--- a/.github/workflows/deploy-lending-service.yml
+++ b/.github/workflows/deploy-lending-service.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "lending-service/**"
+      - ".github/workflows/deploy-lending-service.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/deploy-lido-service.yml
+++ b/.github/workflows/deploy-lido-service.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "lido-service/**"
+      - ".github/workflows/deploy-lido-service.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/deploy-liquid-swap.yml
+++ b/.github/workflows/deploy-liquid-swap.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "liquid-swap-service/**"
+      - "shared/token-registry.json"
+      - ".github/workflows/deploy-liquid-swap.yml"
   workflow_dispatch:
 
 permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ liquid-swap-service/package-lock.json
 *./package-lock.json
 # Temporary token registry copy for builds
 liquid-swap-service/shared/token-registry.json
+bridge-service/shared/token-registry.json
 
 # Terraform local working directory and state
 **/.terraform/

--- a/bridge-service/Dockerfile
+++ b/bridge-service/Dockerfile
@@ -35,6 +35,7 @@ WORKDIR /app
 COPY --from=builder --chown=tacservice:nodejs /app/dist ./dist
 COPY --from=builder --chown=tacservice:nodejs /app/node_modules ./node_modules
 COPY --from=builder --chown=tacservice:nodejs /app/package.json ./package.json
+COPY --from=builder --chown=tacservice:nodejs /app/shared ./shared
 
 # Create logs directory
 RUN mkdir -p /app/logs && chown -R tacservice:nodejs /app/logs

--- a/cloud/iac/terraform/modules/container_app/main.tf
+++ b/cloud/iac/terraform/modules/container_app/main.tf
@@ -58,7 +58,10 @@ resource "azurerm_container_app" "this" {
       memory = var.memory
 
       dynamic "env" {
-        for_each = var.plain_env
+        for_each = {
+          for name, value in var.plain_env : name => value
+          if value != ""
+        }
 
         content {
           name  = env.key


### PR DESCRIPTION
## Summary
- Fix bridge image build to use the production Docker stage
- Include  in the bridge image at runtime
- Omit empty plain env vars from Terraform-managed Container Apps
- Add path filters so public API workflows only run when their service changes

## Why
Bridge was failing in ACA because optional URL env vars were passed as empty strings and the token registry file was missing from the container image. The bridge workflow was also building the Dockerfile’s development stage by default.

## Validation
- `terraform -chdir=cloud/iac/terraform fmt -check -recursive`
- `terraform -chdir=cloud/iac/terraform validate`
- Applied Terraform env filtering plan
- Verified bridge deployment logs progressed past env validation