### PR TITLE
[#199–#203] Capability Contracts — @panorama/capability foundation

### DIFF
--- a/shared/capability/.gitignore
+++ b/shared/capability/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+coverage/
+*.log
+.DS_Store

--- a/shared/capability/CONVENTIONS.md
+++ b/shared/capability/CONVENTIONS.md
@@ -1,0 +1,183 @@
+# @panorama/capability — Conventions
+
+This package is the **foundation** consumed by every backend service. The conventions below are intentionally rigid: drift breaks the shared contract and ripples through 6 services. Read this before adding to `shared/capability/` or before consuming it in a service.
+
+For the architectural rationale, see `execution-layer/docs/adr/002-capability-provider-abstraction.md` and `004-layer-dependency-rules.md`.
+
+---
+
+## 1. Vocabulary
+
+| Term | Meaning |
+|---|---|
+| **Capability** | A verb-shaped backend ability. The closed set: `swap`, `lending`, `staking`, `liquidity`, `bridge`, `automation`. Adding one requires an ADR. |
+| **Provider** | A concrete implementation of one capability (e.g. `uniswap`, `lido`, `benqi`). String name, lowercase. |
+| **Adapter** | Same class as a Provider — "adapter" emphasises the hex architecture role; "provider" emphasises the business role. |
+| **Port** | The interface every provider of a capability must implement (`I<Cap>Provider`). |
+| **Registry** | Generic container holding providers; answers `listByChain`, `getByName`. |
+| **Policy** | Strategy that ranks providers for a given request (priority list per chain). |
+| **Facade / Capability Service** | Application-layer service that orchestrates registry + policy + selected provider per request. |
+| **Envelope** | `CapabilityRequest<T>` / `CapabilityResponse<T>` — the shape every capability speaks. |
+
+---
+
+## 2. File naming
+
+Inside `shared/capability/` and inside any consumer service:
+
+| Pattern | Example | Where |
+|---|---|---|
+| `<thing>.types.ts` | `envelope.types.ts`, `provider.types.ts` | shared types/interfaces |
+| `<thing>.ts` | `errors.ts`, `registry.ts`, `policy.ts` | runtime modules |
+| `<cap>.provider.port.ts` | `swap.provider.port.ts` | port (interface) in a service's `domain/ports/` |
+| `<provider>.<cap>.adapter.ts` | `uniswap.swap.adapter.ts`, `lido.provider.adapter.ts` | adapter in `infrastructure/adapters/` |
+| `<cap>.capability.service.ts` | `swap.capability.service.ts` | facade in `application/services/` |
+| `<thing>.test.ts` | `envelope.types.test.ts` | tests, colocated under `__tests__/` |
+| `<resource>.schema.ts` | `provider.schema.ts` | optional runtime validation (Zod) for a `.types.ts` sibling |
+
+---
+
+## 3. TypeScript suffixes (mandatory)
+
+| Suffix | Meaning |
+|---|---|
+| `Port` | Interface that providers/adapters implement. Example: `ISwapProvider`, `IStakingProvider`. Always prefixed with `I`. |
+| `Adapter` | Concrete implementation of a port. Example: `UniswapSwapAdapter`, `LidoProviderAdapter`. |
+| `Service` | Application layer orchestrator. Example: `SwapCapabilityService`, `ProviderSelectorService`. |
+| `Repository` | Domain persistence interface (not provider-related). |
+| `UseCase` | Single-purpose application script. |
+
+---
+
+## 4. HTTP endpoint pattern
+
+```
+/v1/capability/<capability-slug>/<action>
+```
+
+- **`<capability-slug>`** = lowercase kebab-case from the closed set (`swap`, `lending`, `staking`, `liquidity`, `bridge`, `automation`).
+- **`<action>`** = kebab-case verb or noun (`quote`, `prepare-stake`, `position/:address`, `_discovery`).
+- Special endpoints prefixed with `_` (underscore) are introspective: `_discovery`, `_health`. Reserved.
+
+Examples:
+
+| Capability | Endpoint |
+|---|---|
+| swap | `POST /v1/capability/swap/quote` |
+| swap | `POST /v1/capability/swap/prepare` |
+| lending | `GET /v1/capability/lending/pools/:chainId` |
+| lending | `POST /v1/capability/lending/prepare-supply` |
+| staking | `GET /v1/capability/staking/position/:address` |
+| any | `GET /v1/capability/_discovery` |
+
+**Backward compatibility:** old per-service routes (e.g. `/api/swap/*`, `/api/lending/benqi/*`) continue to serve with a `Deprecation: true` + `Sunset: <date>` header for one release after the capability namespace is live. Then they're removed in a cleanup PR.
+
+---
+
+## 5. Provider naming
+
+Provider name = lowercase, ASCII, no spaces. One token where possible.
+
+| ✅ Good | ❌ Bad |
+|---|---|
+| `uniswap` | `Uniswap`, `Uni Swap` |
+| `uniswap-trading-api` | `uniswapTradingAPI` |
+| `lido` | `lido-finance` (redundant) |
+| `traderjoe` | `trader-joe` (split decision: stay one-word to match how the protocol brands itself) |
+| `aave` | `Aave V3` (versioning goes in `metadata.version`, not the name) |
+
+Mapping protocol → provider names lives in each service's `infrastructure/di/container.ts`.
+
+---
+
+## 6. Error code pattern
+
+```
+CAPABILITY_<CAP>_<TYPE>
+```
+
+- `<CAP>` = uppercase capability slug.
+- `<TYPE>` = uppercase, snake_case-like, describes the failure category for FE/agents.
+
+Examples:
+
+| Code | Meaning |
+|---|---|
+| `CAPABILITY_SWAP_NO_LIQUIDITY` | No pool depth for the requested swap |
+| `CAPABILITY_SWAP_UNSUPPORTED_ROUTE` | No provider supports `from→to` on this chain |
+| `CAPABILITY_LENDING_INSUFFICIENT_COLLATERAL` | Borrow would exceed health factor |
+| `CAPABILITY_STAKING_AMOUNT_TOO_SMALL` | Below protocol minimum |
+| `CAPABILITY_BRIDGE_DESTINATION_UNAVAILABLE` | Source chain OK, dest chain unreachable |
+| `CAPABILITY_AUTOMATION_INVALID_SCHEDULE` | Cron expression invalid |
+| `CAPABILITY_AUTH_CHALLENGE_EXPIRED` | Nonce older than TTL |
+
+**Always** throw a `CapabilityError` with a code in this format. Never `throw new Error(string)` in capability code paths — codes are the API the FE pattern-matches on.
+
+---
+
+## 7. Imports — what's allowed
+
+Every file in `shared/capability/`:
+
+✅ Imports allowed:
+- Standard lib / built-in Node
+- Whitelisted external libs: `zod` (optional, for runtime schemas)
+- Other modules **within** `shared/capability/`
+
+❌ Imports forbidden:
+- Anything under `backend/<service>/*` (cross-service or service-to-foundation invert)
+- Anything under `execution-layer/*`
+- Heavy frameworks (no Express, no Fastify, no Nest — `shared/capability` must stay framework-agnostic)
+
+Service consumers import from `shared/capability/` via path mapping in their `tsconfig.json`:
+
+```jsonc
+// in <service>/tsconfig.json
+{
+  "compilerOptions": {
+    "paths": {
+      "@panorama/capability": ["../shared/capability/index.ts"],
+      "@panorama/capability/*": ["../shared/capability/*"]
+    }
+  }
+}
+```
+
+The first card that consumes `shared/capability/` from a service is responsible for adding the paths block to that service's tsconfig.
+
+---
+
+## 8. Testing
+
+- **Unit tests** colocated in `__tests__/<file>.test.ts` (same dir, suffixed).
+- **Vitest** as the runner. No Jest in this package.
+- **No mocking of `shared/capability/`** from inside `shared/capability/`. If something is hard to test without mocking, the design needs refactor.
+- **Conformance helpers** for cross-service reuse are exported (e.g. `__tests__/registry.conformance.ts` from card #210) — they are documented as part of the public API of the package.
+
+Run: `npm test` (from `shared/capability/`) or `npm run test:watch`.
+
+---
+
+## 9. Versioning
+
+This package is `0.x` while the sprint is in flight. After the sprint review (semana 4), promote to `1.0.0` with a CHANGELOG entry summarising the locked API surface.
+
+Inside `0.x`, breaking changes are allowed but must be announced in `#panorama-dev` with a 24h heads-up.
+
+---
+
+## 10. When in doubt
+
+- If a type is needed by 2+ services → it goes in `shared/capability/`.
+- If a class has runtime logic and 2+ services need it → it goes in `shared/capability/`.
+- If only 1 service uses it → it stays in that service.
+- If a rule isn't covered here → ask the foundation owner (Hugo) before adding; the alternative is silent drift across services.
+
+---
+
+## See also
+
+- ADR 002 — Capability + Provider abstraction (`execution-layer/docs/adr/002-...`)
+- ADR 003 — Lane and feature taxonomy
+- ADR 004 — Layer dependency rules
+- `SPRINT_KICKOFF.md` § 3 (capability pattern in 5 layers)

--- a/shared/capability/__tests__/availability.types.test.ts
+++ b/shared/capability/__tests__/availability.types.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect } from "vitest";
+
+import { buildAvailabilityMap } from "../availability.types";
+import type { ICapabilityProvider, ProviderHealth } from "../provider.types";
+
+function fakeProvider(input: {
+  name: string;
+  capability:
+    | "swap"
+    | "lending"
+    | "staking"
+    | "liquidity"
+    | "bridge"
+    | "automation"
+    | "auth";
+  supportedChains: number[];
+  enabled?: boolean;
+}): ICapabilityProvider {
+  return {
+    name: input.name,
+    metadata: {
+      name: input.name,
+      capability: input.capability,
+      supportedChains: input.supportedChains,
+      version: "1.0.0",
+      ...(input.enabled !== undefined && { enabled: input.enabled }),
+    },
+  };
+}
+
+const FIXED_NOW = () => new Date("2026-05-22T14:00:00.000Z");
+
+describe("buildAvailabilityMap — basics", () => {
+  it("returns empty capabilities when no providers", () => {
+    const map = buildAvailabilityMap({ providers: [], now: FIXED_NOW });
+    expect(map.capabilities).toEqual([]);
+    expect(map.generatedAt).toBe("2026-05-22T14:00:00.000Z");
+    expect(map.cacheTtlSeconds).toBe(30);
+  });
+
+  it("uses cacheTtlSeconds when provided", () => {
+    const map = buildAvailabilityMap({
+      providers: [],
+      cacheTtlSeconds: 60,
+      now: FIXED_NOW,
+    });
+    expect(map.cacheTtlSeconds).toBe(60);
+  });
+});
+
+describe("buildAvailabilityMap — grouping", () => {
+  const providers: ICapabilityProvider[] = [
+    fakeProvider({ name: "uniswap", capability: "swap", supportedChains: [1, 8453] }),
+    fakeProvider({ name: "aerodrome", capability: "swap", supportedChains: [8453] }),
+    fakeProvider({ name: "lido", capability: "staking", supportedChains: [1] }),
+  ];
+
+  it("groups providers by capability and chain", () => {
+    const map = buildAvailabilityMap({ providers, now: FIXED_NOW });
+    expect(map.capabilities).toHaveLength(2);
+
+    const staking = map.capabilities.find((c) => c.capability === "staking");
+    expect(staking?.byChain[1]).toHaveLength(1);
+    expect(staking?.byChain[1]?.[0]?.provider).toBe("lido");
+
+    const swap = map.capabilities.find((c) => c.capability === "swap");
+    expect(Object.keys(swap?.byChain ?? {})).toEqual(["1", "8453"]);
+    expect(swap?.byChain[1]?.map((p) => p.provider)).toEqual(["uniswap"]);
+    expect(swap?.byChain[8453]?.map((p) => p.provider).sort()).toEqual([
+      "aerodrome",
+      "uniswap",
+    ]);
+  });
+
+  it("sorts capabilities alphabetically", () => {
+    const map = buildAvailabilityMap({ providers, now: FIXED_NOW });
+    expect(map.capabilities.map((c) => c.capability)).toEqual(["staking", "swap"]);
+  });
+
+  it("sorts providers within a chain alphabetically", () => {
+    const map = buildAvailabilityMap({ providers, now: FIXED_NOW });
+    const swap = map.capabilities.find((c) => c.capability === "swap");
+    expect(swap?.byChain[8453]?.map((p) => p.provider)).toEqual([
+      "aerodrome",
+      "uniswap",
+    ]);
+  });
+
+  it("sorts chain ids numerically (not lexicographically)", () => {
+    const p = [
+      fakeProvider({ name: "x", capability: "swap", supportedChains: [100, 1, 8453] }),
+    ];
+    const map = buildAvailabilityMap({ providers: p, now: FIXED_NOW });
+    const swap = map.capabilities[0];
+    expect(Object.keys(swap?.byChain ?? {})).toEqual(["1", "100", "8453"]);
+  });
+});
+
+describe("buildAvailabilityMap — enabled flag", () => {
+  it("skips providers with enabled: false (stubs)", () => {
+    const map = buildAvailabilityMap({
+      providers: [
+        fakeProvider({ name: "lido", capability: "staking", supportedChains: [1] }),
+        fakeProvider({
+          name: "base-staking-stub",
+          capability: "staking",
+          supportedChains: [8453],
+          enabled: false,
+        }),
+      ],
+      now: FIXED_NOW,
+    });
+    const staking = map.capabilities[0];
+    expect(Object.keys(staking?.byChain ?? {})).toEqual(["1"]);
+    expect(staking?.byChain[1]?.map((p) => p.provider)).toEqual(["lido"]);
+  });
+
+  it("includes providers with enabled: true explicitly", () => {
+    const map = buildAvailabilityMap({
+      providers: [
+        fakeProvider({
+          name: "lido",
+          capability: "staking",
+          supportedChains: [1],
+          enabled: true,
+        }),
+      ],
+      now: FIXED_NOW,
+    });
+    expect(map.capabilities[0]?.byChain[1]?.[0]?.provider).toBe("lido");
+  });
+});
+
+describe("buildAvailabilityMap — health overlay", () => {
+  const providers = [
+    fakeProvider({ name: "uniswap", capability: "swap", supportedChains: [1] }),
+    fakeProvider({ name: "aerodrome", capability: "swap", supportedChains: [8453] }),
+  ];
+
+  it("defaults to healthy when no health snapshot provided", () => {
+    const map = buildAvailabilityMap({ providers, now: FIXED_NOW });
+    const swap = map.capabilities[0];
+    for (const chain of Object.values(swap?.byChain ?? {})) {
+      for (const p of chain) {
+        expect(p.healthy).toBe(true);
+        expect(p.latencyP95Ms).toBeUndefined();
+        expect(p.lastError).toBeUndefined();
+      }
+    }
+  });
+
+  it("applies health from Map", () => {
+    const health = new Map<string, ProviderHealth>([
+      ["uniswap", { healthy: true, latencyMs: 240, checkedAt: "2026-05-22T13:59:30Z" }],
+      [
+        "aerodrome",
+        {
+          healthy: false,
+          latencyMs: 5000,
+          reason: "rate-limit",
+          checkedAt: "2026-05-22T13:59:45Z",
+        },
+      ],
+    ]);
+    const map = buildAvailabilityMap({ providers, healthByName: health, now: FIXED_NOW });
+    const swap = map.capabilities[0];
+    const uni = swap?.byChain[1]?.[0];
+    const aero = swap?.byChain[8453]?.[0];
+    expect(uni?.healthy).toBe(true);
+    expect(uni?.latencyP95Ms).toBe(240);
+    expect(uni?.lastError).toBeUndefined();
+    expect(aero?.healthy).toBe(false);
+    expect(aero?.lastError).toBe("rate-limit");
+    expect(aero?.lastCheckedAt).toBe("2026-05-22T13:59:45Z");
+  });
+
+  it("applies health from plain object", () => {
+    const map = buildAvailabilityMap({
+      providers,
+      healthByName: {
+        uniswap: { healthy: false, reason: "down", checkedAt: "2026-05-22T13:00Z" },
+      },
+      now: FIXED_NOW,
+    });
+    const uni = map.capabilities[0]?.byChain[1]?.[0];
+    expect(uni?.healthy).toBe(false);
+    expect(uni?.lastError).toBe("down");
+  });
+
+  it("truncates long error reasons to 120 chars", () => {
+    const longReason = "x".repeat(500);
+    const map = buildAvailabilityMap({
+      providers,
+      healthByName: { uniswap: { healthy: false, reason: longReason, checkedAt: "now" } },
+      now: FIXED_NOW,
+    });
+    const uni = map.capabilities[0]?.byChain[1]?.[0];
+    expect(uni?.lastError).toHaveLength(120);
+  });
+});
+
+describe("buildAvailabilityMap — same provider on multiple chains", () => {
+  it("repeats the provider entry per supported chain", () => {
+    const map = buildAvailabilityMap({
+      providers: [
+        fakeProvider({
+          name: "thirdweb-bridge",
+          capability: "bridge",
+          supportedChains: [1, 8453, 43114],
+        }),
+      ],
+      healthByName: {
+        "thirdweb-bridge": { healthy: true, latencyMs: 80, checkedAt: "now" },
+      },
+      now: FIXED_NOW,
+    });
+    const bridge = map.capabilities[0];
+    expect(Object.keys(bridge?.byChain ?? {})).toHaveLength(3);
+    for (const chainList of Object.values(bridge?.byChain ?? {})) {
+      expect(chainList).toHaveLength(1);
+      expect(chainList[0]?.provider).toBe("thirdweb-bridge");
+      expect(chainList[0]?.latencyP95Ms).toBe(80);
+    }
+  });
+});

--- a/shared/capability/__tests__/envelope.types.test.ts
+++ b/shared/capability/__tests__/envelope.types.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, expectTypeOf } from "vitest";
+
+import {
+  isSuccess,
+  isError,
+  buildSuccess,
+  buildError,
+  type CapabilityRequest,
+  type CapabilityResponse,
+  type CapabilitySuccessResponse,
+  type CapabilityErrorResponse,
+  type Transaction,
+} from "../envelope.types";
+import { CapabilityError, ErrorCategory } from "../errors";
+
+describe("envelope.types — CapabilityRequest", () => {
+  it("accepts a typed payload", () => {
+    interface SwapQuotePayload {
+      fromToken: string;
+      toToken: string;
+      amount: string;
+    }
+    const req: CapabilityRequest<SwapQuotePayload> = {
+      tenantId: "telegram-user-12345",
+      traceId: "abc-123",
+      chainId: 8453,
+      userAddress: "0xabc",
+      payload: { fromToken: "USDC", toToken: "ETH", amount: "100000000" },
+    };
+    expect(req.payload.fromToken).toBe("USDC");
+    expectTypeOf(req.payload).toEqualTypeOf<SwapQuotePayload>();
+  });
+
+  it("idempotencyKey is optional", () => {
+    const req: CapabilityRequest<{ x: number }> = {
+      tenantId: "t",
+      traceId: "u",
+      chainId: 1,
+      userAddress: "0x",
+      payload: { x: 1 },
+    };
+    expect(req.idempotencyKey).toBeUndefined();
+  });
+});
+
+describe("envelope.types — type guards", () => {
+  const success: CapabilitySuccessResponse<number> = {
+    status: "success",
+    data: 42,
+    provider: { name: "uniswap" },
+    traceId: "abc-123",
+    latencyMs: 87,
+  };
+  const errorResp: CapabilityErrorResponse = {
+    status: "error",
+    error: {
+      code: "CAPABILITY_SWAP_NO_LIQUIDITY",
+      category: "INSUFFICIENT_LIQUIDITY",
+      message: "no",
+      httpStatus: 422,
+    },
+    traceId: "abc-123",
+    latencyMs: 12,
+  };
+
+  it("isSuccess narrows to success variant", () => {
+    const r: CapabilityResponse<number> = success;
+    if (isSuccess(r)) {
+      expectTypeOf(r.data).toBeNumber();
+      expect(r.data).toBe(42);
+    } else {
+      throw new Error("should have narrowed to success");
+    }
+  });
+
+  it("isError narrows to error variant", () => {
+    const r: CapabilityResponse<number> = errorResp;
+    if (isError(r)) {
+      expectTypeOf(r.error.code).toBeString();
+      expect(r.error.code).toBe("CAPABILITY_SWAP_NO_LIQUIDITY");
+    } else {
+      throw new Error("should have narrowed to error");
+    }
+  });
+
+  it("isSuccess and isError are mutually exclusive", () => {
+    const responses: CapabilityResponse<number>[] = [success, errorResp];
+    for (const r of responses) {
+      expect(isSuccess(r) === isError(r)).toBe(false);
+    }
+  });
+});
+
+describe("envelope.types — buildSuccess", () => {
+  it("builds a minimal success response", () => {
+    const r = buildSuccess({
+      data: { expectedAmount: "0.0312" },
+      provider: { name: "aerodrome" },
+      traceId: "abc-123",
+      latencyMs: 187,
+    });
+    expect(r.status).toBe("success");
+    expect(r.data.expectedAmount).toBe("0.0312");
+    expect(r.provider.name).toBe("aerodrome");
+    expect(r.attemptedProviders).toBeUndefined();
+  });
+
+  it("preserves attemptedProviders when provided", () => {
+    const r = buildSuccess({
+      data: 1,
+      provider: { name: "uniswap" },
+      traceId: "t",
+      latencyMs: 50,
+      attemptedProviders: [{ name: "aerodrome", reason: "unhealthy" }],
+    });
+    expect(r.attemptedProviders).toHaveLength(1);
+    expect(r.attemptedProviders?.[0]?.name).toBe("aerodrome");
+  });
+});
+
+describe("envelope.types — buildError", () => {
+  it("serializes a CapabilityError into the response envelope", () => {
+    const err = new CapabilityError({
+      code: "CAPABILITY_SWAP_NO_LIQUIDITY",
+      category: ErrorCategory.INSUFFICIENT_LIQUIDITY,
+      message: "Pool depth insufficient",
+      provider: "aerodrome",
+    });
+    const r = buildError({
+      error: err,
+      traceId: "abc-123",
+      latencyMs: 12,
+    });
+    expect(r.status).toBe("error");
+    expect(r.error.code).toBe("CAPABILITY_SWAP_NO_LIQUIDITY");
+    expect(r.error.category).toBe("INSUFFICIENT_LIQUIDITY");
+    expect(r.error.httpStatus).toBe(422);
+    expect(r.error.provider).toBe("aerodrome");
+  });
+});
+
+describe("envelope.types — Transaction shape", () => {
+  it("accepts a minimum valid transaction", () => {
+    const tx: Transaction = {
+      chainId: 8453,
+      to: "0x1234",
+      data: "0xabcd",
+      value: "0",
+    };
+    expect(tx.value).toBe("0");
+  });
+
+  it("accepts EIP-1559 fee fields", () => {
+    const tx: Transaction = {
+      chainId: 1,
+      to: "0xabc",
+      data: "0x",
+      value: "1000000",
+      maxFeePerGas: "30000000000",
+      maxPriorityFeePerGas: "1000000000",
+      feeMode: "authoritative",
+    };
+    expect(tx.feeMode).toBe("authoritative");
+  });
+});

--- a/shared/capability/__tests__/errors.test.ts
+++ b/shared/capability/__tests__/errors.test.ts
@@ -1,0 +1,243 @@
+import { describe, it, expect } from "vitest";
+
+import { CapabilityError, ErrorCategory, categoryToHttpStatus } from "../errors";
+
+describe("ErrorCategory → httpStatus map", () => {
+  it("maps every category to a known status", () => {
+    const expected: Record<ErrorCategory, number> = {
+      [ErrorCategory.VALIDATION]: 400,
+      [ErrorCategory.UNSUPPORTED_ROUTE]: 404,
+      [ErrorCategory.RATE_LIMITED]: 429,
+      [ErrorCategory.INSUFFICIENT_LIQUIDITY]: 422,
+      [ErrorCategory.INTERNAL]: 500,
+      [ErrorCategory.PROVIDER_FAILURE]: 502,
+      [ErrorCategory.UNAVAILABLE]: 503,
+    };
+    for (const [cat, status] of Object.entries(expected)) {
+      expect(categoryToHttpStatus(cat as ErrorCategory)).toBe(status);
+    }
+  });
+});
+
+describe("CapabilityError — constructor", () => {
+  it("inherits from Error and preserves message", () => {
+    const err = new CapabilityError({
+      code: "CAPABILITY_SWAP_NO_LIQUIDITY",
+      category: ErrorCategory.INSUFFICIENT_LIQUIDITY,
+      message: "No depth",
+    });
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toBe("No depth");
+    expect(err.name).toBe("CapabilityError");
+  });
+
+  it("defaults httpStatus from category", () => {
+    const err = new CapabilityError({
+      code: "CAPABILITY_SWAP_UNSUPPORTED_ROUTE",
+      category: ErrorCategory.UNSUPPORTED_ROUTE,
+      message: "no route",
+    });
+    expect(err.httpStatus).toBe(404);
+  });
+
+  it("allows explicit httpStatus override", () => {
+    const err = new CapabilityError({
+      code: "CAPABILITY_SWAP_RATE_LIMITED",
+      category: ErrorCategory.RATE_LIMITED,
+      message: "slow down",
+      httpStatus: 418, // intentionally weird
+    });
+    expect(err.httpStatus).toBe(418);
+  });
+
+  it("preserves stack trace originating at the throw site, not the constructor", () => {
+    const err = new CapabilityError({
+      code: "CAPABILITY_INTERNAL_ERROR",
+      category: ErrorCategory.INTERNAL,
+      message: "boom",
+    });
+    expect(err.stack).toBeDefined();
+    // The first frame should NOT be inside the CapabilityError constructor.
+    expect(err.stack?.split("\n")[1] ?? "").not.toMatch(/at new CapabilityError/);
+  });
+
+  it("preserves cause for logs but does not expose it on the wire", () => {
+    const underlying = new Error("ethers: insufficient funds");
+    const err = new CapabilityError({
+      code: "CAPABILITY_SWAP_PROVIDER_FAILURE",
+      category: ErrorCategory.PROVIDER_FAILURE,
+      message: "swap failed",
+      cause: underlying,
+    });
+    expect(err.cause).toBe(underlying);
+    expect(err.toSerialized()).not.toHaveProperty("cause");
+  });
+});
+
+describe("CapabilityError — toSerialized", () => {
+  it("produces JSON-safe shape with required fields", () => {
+    const err = new CapabilityError({
+      code: "CAPABILITY_LENDING_INSUFFICIENT_COLLATERAL",
+      category: ErrorCategory.INSUFFICIENT_LIQUIDITY,
+      message: "health factor too low",
+      provider: "benqi",
+      details: { hf: 0.95, threshold: 1.0 },
+    });
+    const wire = err.toSerialized();
+    expect(wire).toEqual({
+      code: "CAPABILITY_LENDING_INSUFFICIENT_COLLATERAL",
+      category: "INSUFFICIENT_LIQUIDITY",
+      message: "health factor too low",
+      provider: "benqi",
+      details: { hf: 0.95, threshold: 1.0 },
+      httpStatus: 422,
+    });
+    expect(() => JSON.stringify(wire)).not.toThrow();
+  });
+
+  it("omits provider when absent", () => {
+    const err = new CapabilityError({
+      code: "CAPABILITY_INTERNAL_ERROR",
+      category: ErrorCategory.INTERNAL,
+      message: "x",
+    });
+    expect(err.toSerialized()).not.toHaveProperty("provider");
+  });
+
+  it("omits details when absent", () => {
+    const err = new CapabilityError({
+      code: "CAPABILITY_INTERNAL_ERROR",
+      category: ErrorCategory.INTERNAL,
+      message: "x",
+    });
+    expect(err.toSerialized()).not.toHaveProperty("details");
+  });
+});
+
+describe("CapabilityError.is (structural check)", () => {
+  it("returns true for an instance", () => {
+    const err = new CapabilityError({
+      code: "X",
+      category: ErrorCategory.INTERNAL,
+      message: "y",
+    });
+    expect(CapabilityError.is(err)).toBe(true);
+  });
+
+  it("returns true for a structurally-equivalent object (cross-module case)", () => {
+    const dup = {
+      name: "CapabilityError",
+      code: "X",
+      category: "INTERNAL",
+      message: "y",
+      httpStatus: 500,
+    };
+    expect(CapabilityError.is(dup)).toBe(true);
+  });
+
+  it("returns false for plain Error", () => {
+    expect(CapabilityError.is(new Error("plain"))).toBe(false);
+  });
+
+  it("returns false for arbitrary objects and primitives", () => {
+    expect(CapabilityError.is({})).toBe(false);
+    expect(CapabilityError.is(null)).toBe(false);
+    expect(CapabilityError.is("string")).toBe(false);
+    expect(CapabilityError.is(undefined)).toBe(false);
+  });
+});
+
+describe("CapabilityError factories", () => {
+  it("unsupportedRoute builds a 404 with attempted providers", () => {
+    const err = CapabilityError.unsupportedRoute({
+      capability: "swap",
+      chainId: 8453,
+      attempted: ["aerodrome", "uniswap"],
+      fromAsset: "USDC",
+      toAsset: "ETH",
+    });
+    expect(err.category).toBe(ErrorCategory.UNSUPPORTED_ROUTE);
+    expect(err.httpStatus).toBe(404);
+    expect(err.code).toBe("CAPABILITY_SWAP_UNSUPPORTED_ROUTE");
+    expect(err.message).toContain("aerodrome");
+    expect(err.message).toContain("uniswap");
+    expect(err.details).toMatchObject({
+      capability: "swap",
+      chainId: 8453,
+      fromAsset: "USDC",
+      toAsset: "ETH",
+    });
+  });
+
+  it("allProvidersFailed is 503 with per-provider attempts", () => {
+    const err = CapabilityError.allProvidersFailed({
+      capability: "lending",
+      attempts: [
+        { provider: "benqi", error: "timeout" },
+        { provider: "moonwell-stub", error: "disabled" },
+      ],
+    });
+    expect(err.category).toBe(ErrorCategory.UNAVAILABLE);
+    expect(err.httpStatus).toBe(503);
+    expect(err.code).toBe("CAPABILITY_LENDING_ALL_PROVIDERS_FAILED");
+    expect(err.details).toMatchObject({
+      capability: "lending",
+      attempts: [
+        { provider: "benqi", error: "timeout" },
+        { provider: "moonwell-stub", error: "disabled" },
+      ],
+    });
+  });
+
+  it("validation produces a 400 with the optional zod errors bag", () => {
+    const err = CapabilityError.validation({
+      capability: "swap",
+      message: "amount must be > 0",
+      errors: [{ path: ["amount"], message: "min 1" }],
+    });
+    expect(err.httpStatus).toBe(400);
+    expect(err.code).toBe("CAPABILITY_SWAP_VALIDATION_FAILED");
+    expect(err.details).toEqual({
+      errors: [{ path: ["amount"], message: "min 1" }],
+    });
+  });
+
+  it("providerFailure preserves cause off the wire", () => {
+    const root = new Error("eth_call reverted");
+    const err = CapabilityError.providerFailure({
+      capability: "lending",
+      provider: "benqi",
+      message: "supply tx reverted",
+      cause: root,
+    });
+    expect(err.cause).toBe(root);
+    expect(err.toSerialized()).not.toHaveProperty("cause");
+    expect(err.provider).toBe("benqi");
+  });
+
+  it("rateLimited carries optional retryAfterMs", () => {
+    const err = CapabilityError.rateLimited({
+      capability: "swap",
+      provider: "uniswap",
+      retryAfterMs: 5000,
+    });
+    expect(err.httpStatus).toBe(429);
+    expect(err.details).toEqual({ retryAfterMs: 5000 });
+  });
+
+  it("internal produces a 500 with cause", () => {
+    const root = new TypeError("undefined is not a function");
+    const err = CapabilityError.internal("orchestrator bug", root);
+    expect(err.httpStatus).toBe(500);
+    expect(err.code).toBe("CAPABILITY_INTERNAL_ERROR");
+    expect(err.cause).toBe(root);
+  });
+
+  it("unavailable produces a 503 with optional details", () => {
+    const err = CapabilityError.unavailable("Staking on Base not implemented yet", {
+      stub: "BaseStakingProviderAdapter",
+    });
+    expect(err.httpStatus).toBe(503);
+    expect(err.details).toEqual({ stub: "BaseStakingProviderAdapter" });
+  });
+});

--- a/shared/capability/__tests__/provider.types.test.ts
+++ b/shared/capability/__tests__/provider.types.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  CAPABILITY_SLUGS,
+  isCapabilitySlug,
+  validateProviderMetadata,
+  type ProviderMetadata,
+  type ICapabilityProvider,
+} from "../provider.types";
+
+describe("CapabilitySlug", () => {
+  it("CAPABILITY_SLUGS is non-empty and unique", () => {
+    expect(CAPABILITY_SLUGS.length).toBeGreaterThan(0);
+    expect(new Set(CAPABILITY_SLUGS).size).toBe(CAPABILITY_SLUGS.length);
+  });
+
+  it("isCapabilitySlug accepts every slug in the closed set", () => {
+    for (const slug of CAPABILITY_SLUGS) {
+      expect(isCapabilitySlug(slug)).toBe(true);
+    }
+  });
+
+  it("isCapabilitySlug rejects unknown values", () => {
+    expect(isCapabilitySlug("derivatives")).toBe(false);
+    expect(isCapabilitySlug("Swap")).toBe(false); // case-sensitive
+    expect(isCapabilitySlug("")).toBe(false);
+    expect(isCapabilitySlug(42)).toBe(false);
+    expect(isCapabilitySlug(null)).toBe(false);
+    expect(isCapabilitySlug(undefined)).toBe(false);
+  });
+});
+
+describe("validateProviderMetadata — happy path", () => {
+  it("accepts a complete valid metadata", () => {
+    const m: ProviderMetadata = {
+      name: "lido",
+      capability: "staking",
+      supportedChains: [1],
+      features: ["stETH", "wstETH"],
+      version: "1.0.0",
+      enabled: true,
+    };
+    expect(validateProviderMetadata(m)).toEqual({ ok: true });
+  });
+
+  it("accepts minimum required fields (features and enabled optional)", () => {
+    const m: ProviderMetadata = {
+      name: "uniswap",
+      capability: "swap",
+      supportedChains: [1, 8453],
+      version: "0.1.0",
+    };
+    expect(validateProviderMetadata(m)).toEqual({ ok: true });
+  });
+
+  it("accepts hyphenated names", () => {
+    const m: ProviderMetadata = {
+      name: "uniswap-trading-api",
+      capability: "swap",
+      supportedChains: [1],
+      version: "1.0.0",
+    };
+    expect(validateProviderMetadata(m)).toEqual({ ok: true });
+  });
+});
+
+describe("validateProviderMetadata — name rules", () => {
+  function meta(name: unknown): unknown {
+    return {
+      name,
+      capability: "swap",
+      supportedChains: [1],
+      version: "1.0.0",
+    };
+  }
+
+  it("rejects empty name", () => {
+    const r = validateProviderMetadata(meta(""));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errors.join(" ")).toMatch(/name must be a non-empty/);
+  });
+
+  it("rejects uppercase name", () => {
+    const r = validateProviderMetadata(meta("Uniswap"));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errors.join(" ")).toMatch(/lowercase/);
+  });
+
+  it("rejects name starting with digit", () => {
+    const r = validateProviderMetadata(meta("1inch"));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errors.join(" ")).toMatch(/must match/);
+  });
+
+  it("rejects name with underscore", () => {
+    const r = validateProviderMetadata(meta("uni_swap"));
+    expect(r.ok).toBe(false);
+  });
+
+  it("rejects non-string name", () => {
+    const r = validateProviderMetadata(meta(42));
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe("validateProviderMetadata — capability rules", () => {
+  it("rejects unknown capability slug", () => {
+    const r = validateProviderMetadata({
+      name: "x",
+      capability: "derivatives",
+      supportedChains: [1],
+      version: "1.0.0",
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errors.join(" ")).toMatch(/capability must be one of/);
+  });
+
+  it("rejects missing capability", () => {
+    const r = validateProviderMetadata({
+      name: "x",
+      supportedChains: [1],
+      version: "1.0.0",
+    });
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe("validateProviderMetadata — supportedChains rules", () => {
+  function meta(supportedChains: unknown): unknown {
+    return {
+      name: "x",
+      capability: "swap",
+      supportedChains,
+      version: "1.0.0",
+    };
+  }
+
+  it("rejects non-array", () => {
+    expect(validateProviderMetadata(meta("8453")).ok).toBe(false);
+  });
+
+  it("rejects empty array", () => {
+    expect(validateProviderMetadata(meta([])).ok).toBe(false);
+  });
+
+  it("rejects array with zero or negative", () => {
+    const r = validateProviderMetadata(meta([0, -1]));
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errors.join(" ")).toMatch(/non-positive-integer/);
+  });
+
+  it("rejects floats", () => {
+    const r = validateProviderMetadata(meta([8453.5]));
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe("validateProviderMetadata — version rules", () => {
+  function meta(version: unknown): unknown {
+    return {
+      name: "x",
+      capability: "swap",
+      supportedChains: [1],
+      version,
+    };
+  }
+
+  it("accepts plain SemVer", () => {
+    expect(validateProviderMetadata(meta("1.0.0")).ok).toBe(true);
+  });
+
+  it("accepts SemVer with pre-release", () => {
+    expect(validateProviderMetadata(meta("1.0.0-beta.1")).ok).toBe(true);
+  });
+
+  it("rejects non-SemVer", () => {
+    expect(validateProviderMetadata(meta("v1")).ok).toBe(false);
+    expect(validateProviderMetadata(meta(1)).ok).toBe(false);
+  });
+});
+
+describe("validateProviderMetadata — top-level shape", () => {
+  it("rejects null", () => {
+    expect(validateProviderMetadata(null).ok).toBe(false);
+  });
+
+  it("rejects non-object", () => {
+    expect(validateProviderMetadata("metadata").ok).toBe(false);
+    expect(validateProviderMetadata(42).ok).toBe(false);
+  });
+
+  it("collects multiple errors", () => {
+    const r = validateProviderMetadata({
+      name: "Bad Name",
+      capability: "unknown",
+      supportedChains: [],
+      version: "not-semver",
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.errors.length).toBeGreaterThanOrEqual(4);
+    }
+  });
+});
+
+describe("ICapabilityProvider — type shape (compile-only)", () => {
+  it("accepts a minimal provider implementation", () => {
+    class FakeProvider implements ICapabilityProvider {
+      readonly name = "fake";
+      readonly metadata: ProviderMetadata = {
+        name: "fake",
+        capability: "swap",
+        supportedChains: [1],
+        version: "1.0.0",
+      };
+    }
+    const p = new FakeProvider();
+    expect(p.name).toBe("fake");
+    expect(p.metadata.capability).toBe("swap");
+  });
+
+  it("accepts a provider with healthCheck", async () => {
+    class FakeProvider implements ICapabilityProvider {
+      readonly name = "fake";
+      readonly metadata: ProviderMetadata = {
+        name: "fake",
+        capability: "swap",
+        supportedChains: [1],
+        version: "1.0.0",
+      };
+      async healthCheck() {
+        return { healthy: true, latencyMs: 12, checkedAt: new Date().toISOString() };
+      }
+    }
+    const p = new FakeProvider();
+    const h = await p.healthCheck!();
+    expect(h.healthy).toBe(true);
+    expect(typeof h.latencyMs).toBe("number");
+  });
+});

--- a/shared/capability/availability.types.ts
+++ b/shared/capability/availability.types.ts
@@ -1,0 +1,152 @@
+/**
+ * Availability schema — what `/v1/capability/_discovery` returns.
+ *
+ * The FE consumes this to drive feature visibility ("Lending on Avax is healthy → show menu;
+ * unhealthy → grey it out"). Agents consume it before proposing actions ("check availability
+ * before suggesting").
+ *
+ * Real construction happens at runtime by the discovery handler (card #207) which queries the
+ * `ProviderRegistry` and `ProviderHealthTracker`. This file defines the **wire shape** and a
+ * stub builder used by tests.
+ *
+ * See CONVENTIONS.md §4 and ADR 002 §"Discovery".
+ */
+
+import type { ChainId } from "./envelope.types";
+import type {
+  CapabilitySlug,
+  ICapabilityProvider,
+  ProviderHealth,
+} from "./provider.types";
+
+// -------------------------------------------------------------------------------------------------
+// Wire shape
+// -------------------------------------------------------------------------------------------------
+
+/**
+ * Single provider's availability on one chain.
+ *
+ * - `healthy: true` means the provider is currently serving traffic.
+ * - `latencyP95Ms` is a rolling 95th percentile from the health tracker; absent on cold start.
+ * - `lastError` is the most recent error message when `healthy: false`; truncated to 120 chars.
+ */
+export interface ProviderAvailability {
+  provider: string;
+  healthy: boolean;
+  latencyP95Ms?: number;
+  lastError?: string;
+  /** ISO 8601 of the last health probe. */
+  lastCheckedAt?: string;
+}
+
+/**
+ * All providers for one capability, grouped by chain.
+ */
+export interface CapabilityAvailability {
+  capability: CapabilitySlug;
+  byChain: Record<ChainId, ProviderAvailability[]>;
+}
+
+/**
+ * The full discovery payload. Returned by `GET /v1/capability/_discovery` (the handler from
+ * card #207 wraps this in a `CapabilityResponse`-shaped envelope plus cache headers).
+ */
+export interface AvailabilityMap {
+  capabilities: CapabilityAvailability[];
+  /** When this snapshot was built. */
+  generatedAt: string; // ISO 8601
+  /** How long the FE / gateway may cache this snapshot. */
+  cacheTtlSeconds: number;
+}
+
+// -------------------------------------------------------------------------------------------------
+// Builder — used by the discovery handler (card #207) and by tests
+// -------------------------------------------------------------------------------------------------
+
+export interface BuildAvailabilityInput {
+  providers: ICapabilityProvider[];
+  /** Map of provider name → latest health probe. Optional; absent → treated as healthy. */
+  healthByName?: Map<string, ProviderHealth> | Record<string, ProviderHealth>;
+  /** Defaults to 30s — same as the server-side cache. */
+  cacheTtlSeconds?: number;
+  /** Defaults to `new Date()`. Injectable for deterministic tests. */
+  now?: () => Date;
+}
+
+/**
+ * Build an `AvailabilityMap` from a list of registered providers + a health snapshot.
+ *
+ * This function is pure: same input → same output. The real-time aspects (RPC probing,
+ * rolling window of probes) live in `ProviderHealthTracker` (card #209), not here.
+ *
+ * @example
+ *   const map = buildAvailabilityMap({
+ *     providers: registry.listAll(),
+ *     healthByName: healthTracker.snapshot(),
+ *   });
+ *   res.json({ status: 'success', data: map, ... });
+ */
+export function buildAvailabilityMap(input: BuildAvailabilityInput): AvailabilityMap {
+  const now = (input.now ?? (() => new Date()))();
+  const cacheTtlSeconds = input.cacheTtlSeconds ?? 30;
+
+  const healthLookup = normalizeHealthLookup(input.healthByName);
+
+  // Group: capability → chainId → ProviderAvailability[]
+  const byCapability = new Map<CapabilitySlug, Map<ChainId, ProviderAvailability[]>>();
+
+  for (const p of input.providers) {
+    if (p.metadata.enabled === false) {
+      continue; // Skip stubs; they're built but not announced.
+    }
+
+    const health = healthLookup.get(p.name);
+    const entry: ProviderAvailability = {
+      provider: p.name,
+      healthy: health ? health.healthy : true, // Absent health → optimistic.
+      ...(health?.latencyMs !== undefined && { latencyP95Ms: health.latencyMs }),
+      ...(health?.reason && { lastError: health.reason.slice(0, 120) }),
+      ...(health?.checkedAt && { lastCheckedAt: health.checkedAt }),
+    };
+
+    const cap = p.metadata.capability;
+    const capMap = byCapability.get(cap) ?? new Map<ChainId, ProviderAvailability[]>();
+    byCapability.set(cap, capMap);
+
+    for (const chainId of p.metadata.supportedChains) {
+      const list = capMap.get(chainId) ?? [];
+      list.push(entry);
+      capMap.set(chainId, list);
+    }
+  }
+
+  // Materialise in a stable order: capability slugs alphabetically, chainIds numerically.
+  const capabilities: CapabilityAvailability[] = [];
+  const sortedCaps = [...byCapability.keys()].sort();
+  for (const cap of sortedCaps) {
+    const capMap = byCapability.get(cap);
+    if (!capMap) continue;
+    const byChain: Record<ChainId, ProviderAvailability[]> = {};
+    const sortedChains = [...capMap.keys()].sort((a, b) => a - b);
+    for (const chainId of sortedChains) {
+      const list = capMap.get(chainId);
+      if (!list) continue;
+      byChain[chainId] = [...list].sort((a, b) => a.provider.localeCompare(b.provider));
+    }
+    capabilities.push({ capability: cap, byChain });
+  }
+
+  return {
+    capabilities,
+    generatedAt: now.toISOString(),
+    cacheTtlSeconds,
+  };
+}
+
+function normalizeHealthLookup(
+  input: BuildAvailabilityInput["healthByName"]
+): Map<string, ProviderHealth> {
+  if (!input) return new Map();
+  if (input instanceof Map) return input;
+  return new Map(Object.entries(input));
+}

--- a/shared/capability/envelope.types.ts
+++ b/shared/capability/envelope.types.ts
@@ -1,0 +1,235 @@
+/**
+ * Capability envelope — the request/response shape every capability speaks.
+ *
+ * Every `/v1/capability/<slug>/<action>` endpoint receives a `CapabilityRequest<T>`
+ * (where `T` is the action-specific payload) and returns a `CapabilityResponse<U>`
+ * (where `U` is the action-specific data on success).
+ *
+ * See ADR 002 (capability-provider abstraction) and CONVENTIONS.md.
+ */
+
+import type { CapabilityError } from "./errors";
+
+// -------------------------------------------------------------------------------------------------
+// Common primitives
+// -------------------------------------------------------------------------------------------------
+
+/**
+ * EVM-style address as a 0x-prefixed hex string. Validation (checksum/length) is the consumer's job.
+ */
+export type Address = string;
+
+/**
+ * Numeric chain id (EIP-155). See `chains/` for the manifest of supported chains.
+ */
+export type ChainId = number;
+
+/**
+ * Wei amount serialised as a decimal string. We never pass BigInt over JSON.
+ */
+export type WeiString = string;
+
+/**
+ * RFC 4122 UUID — used for traceId, idempotencyKey.
+ */
+export type Uuid = string;
+
+// -------------------------------------------------------------------------------------------------
+// Provider info attached to every successful response
+// -------------------------------------------------------------------------------------------------
+
+/**
+ * Provider info surfaced back to the caller. The `metadata` bag is provider-specific.
+ *
+ * **Important:** consumers (FE, agents) may display `provider.name` but must not branch on it for
+ * business logic. Provider selection is the backend's job; see ADR 001.
+ */
+export interface ProviderInfo {
+  /** Provider name. Lowercase, ASCII. See CONVENTIONS.md §5. */
+  name: string;
+  /** Free-form provider-specific data: pool id, route hops, on-chain tx ids of intermediate steps. */
+  metadata?: Record<string, unknown>;
+}
+
+// -------------------------------------------------------------------------------------------------
+// Transaction shape — used by every capability that prepares blockchain transactions
+// -------------------------------------------------------------------------------------------------
+
+/**
+ * A prepared blockchain transaction ready for user signature.
+ *
+ * Fee mode:
+ * - `authoritative` — the provider committed to specific gas params and they should be used as-is.
+ * - `advisory` — the provider suggested gas but the signer may override.
+ */
+export interface Transaction {
+  chainId: ChainId;
+  to: Address;
+  data: string; // 0x-prefixed calldata
+  value: WeiString; // wei as decimal string
+  gasLimit?: WeiString;
+  gasPrice?: WeiString;
+  maxFeePerGas?: WeiString;
+  maxPriorityFeePerGas?: WeiString;
+  feeMode?: "authoritative" | "advisory";
+  /** Optional human-readable action label for UX (e.g. "Approve USDC", "Swap USDC → ETH"). */
+  action?: string;
+  /** Optional human-readable description for UX. */
+  description?: string;
+}
+
+// -------------------------------------------------------------------------------------------------
+// Request envelope
+// -------------------------------------------------------------------------------------------------
+
+/**
+ * Standard request envelope. `payload` is the action-specific input.
+ *
+ * Headers ↔ fields:
+ * - `tenantId` ← `x-tenant-id` (mandatory at the public surface; defaulted by the gateway for FE traffic)
+ * - `traceId` ← `x-trace-id` (mandatory; gateway generates if missing)
+ * - `idempotencyKey` ← `x-idempotency-key` (optional; required for state-mutating actions)
+ */
+export interface CapabilityRequest<TPayload> {
+  tenantId: string;
+  traceId: Uuid;
+  /** Required for state-mutating actions (prepare-*, schedule-*). Hash(key + body) → cached response. */
+  idempotencyKey?: Uuid;
+  chainId: ChainId;
+  userAddress: Address;
+  payload: TPayload;
+  /** Receipt metadata — when the request was received by the controller. Filled by middleware. */
+  receivedAt?: string; // ISO 8601
+}
+
+// -------------------------------------------------------------------------------------------------
+// Response envelope (discriminated union)
+// -------------------------------------------------------------------------------------------------
+
+/**
+ * Successful response. `data` is the action-specific result.
+ */
+export interface CapabilitySuccessResponse<TData> {
+  status: "success";
+  data: TData;
+  /** Which provider served this request. Display-only for consumers. */
+  provider: ProviderInfo;
+  traceId: Uuid;
+  /** Time spent in the backend orchestration layer (controller → facade → adapter → back). */
+  latencyMs: number;
+  /** Optional list of providers attempted before the selected one (debug aid). */
+  attemptedProviders?: Array<{ name: string; reason: string }>;
+}
+
+/**
+ * Error response. `error` carries category + code + details for the FE to render UX.
+ */
+export interface CapabilityErrorResponse {
+  status: "error";
+  error: SerializedCapabilityError;
+  /** Provider attempted when the error occurred (undefined if error happened before provider selection). */
+  provider?: ProviderInfo;
+  traceId: Uuid;
+  latencyMs: number;
+  attemptedProviders?: Array<{ name: string; reason: string }>;
+}
+
+/**
+ * The wire format of `CapabilityError`. Serialisation happens in the HTTP layer; this is what FE sees.
+ */
+export interface SerializedCapabilityError {
+  code: string;
+  category: string;
+  message: string;
+  provider?: string;
+  details?: Record<string, unknown>;
+  httpStatus: number;
+}
+
+/**
+ * Union of all responses.
+ */
+export type CapabilityResponse<TData> =
+  | CapabilitySuccessResponse<TData>
+  | CapabilityErrorResponse;
+
+// -------------------------------------------------------------------------------------------------
+// Type guards
+// -------------------------------------------------------------------------------------------------
+
+/**
+ * Narrows a `CapabilityResponse<T>` to its success variant.
+ *
+ * @example
+ *   const r = await capabilityClient.invoke('swap', 'quote', payload);
+ *   if (isSuccess(r)) {
+ *     console.log(r.data.expectedAmount);
+ *   } else {
+ *     console.error(r.error.code);
+ *   }
+ */
+export function isSuccess<T>(
+  response: CapabilityResponse<T>
+): response is CapabilitySuccessResponse<T> {
+  return response.status === "success";
+}
+
+/**
+ * Narrows a `CapabilityResponse<T>` to its error variant.
+ */
+export function isError<T>(
+  response: CapabilityResponse<T>
+): response is CapabilityErrorResponse {
+  return response.status === "error";
+}
+
+// -------------------------------------------------------------------------------------------------
+// Builders (server-side helpers)
+// -------------------------------------------------------------------------------------------------
+
+export interface BuildSuccessInput<TData> {
+  data: TData;
+  provider: ProviderInfo;
+  traceId: Uuid;
+  latencyMs: number;
+  attemptedProviders?: Array<{ name: string; reason: string }>;
+}
+
+/**
+ * Build a success response. Server-side helper; FE does not use this.
+ */
+export function buildSuccess<TData>(
+  input: BuildSuccessInput<TData>
+): CapabilitySuccessResponse<TData> {
+  return {
+    status: "success",
+    data: input.data,
+    provider: input.provider,
+    traceId: input.traceId,
+    latencyMs: input.latencyMs,
+    ...(input.attemptedProviders && { attemptedProviders: input.attemptedProviders }),
+  };
+}
+
+export interface BuildErrorInput {
+  error: CapabilityError;
+  traceId: Uuid;
+  latencyMs: number;
+  provider?: ProviderInfo;
+  attemptedProviders?: Array<{ name: string; reason: string }>;
+}
+
+/**
+ * Build an error response from a `CapabilityError`. The HTTP layer should call this and use
+ * `response.error.httpStatus` for the status code.
+ */
+export function buildError(input: BuildErrorInput): CapabilityErrorResponse {
+  return {
+    status: "error",
+    error: input.error.toSerialized(),
+    traceId: input.traceId,
+    latencyMs: input.latencyMs,
+    ...(input.provider && { provider: input.provider }),
+    ...(input.attemptedProviders && { attemptedProviders: input.attemptedProviders }),
+  };
+}

--- a/shared/capability/errors.ts
+++ b/shared/capability/errors.ts
@@ -1,0 +1,264 @@
+/**
+ * Capability error taxonomy.
+ *
+ * Every capability code path that throws **must** throw a `CapabilityError`. Plain `Error` is
+ * forbidden at the application layer of a capability — it loses the category/code that the FE
+ * pattern-matches on.
+ *
+ * See ADR 002 + CONVENTIONS.md §6.
+ */
+
+import type { SerializedCapabilityError } from "./envelope.types";
+
+// -------------------------------------------------------------------------------------------------
+// Categories — closed set
+// -------------------------------------------------------------------------------------------------
+
+/**
+ * High-level error category. The FE uses this (not `code`) to choose the UX response.
+ *
+ * - **VALIDATION** (400) — the request itself is malformed/illegal.
+ * - **UNSUPPORTED_ROUTE** (404) — no provider supports this route/chain pair.
+ * - **INSUFFICIENT_LIQUIDITY** (422) — the request is well-formed but the market can't fill it.
+ * - **PROVIDER_FAILURE** (502) — an upstream provider returned an error or timed out.
+ * - **RATE_LIMITED** (429) — caller or backend hit a rate cap; retry later.
+ * - **UNAVAILABLE** (503) — all providers down/unhealthy; capability temporarily disabled.
+ * - **INTERNAL** (500) — bug in the backend; the FE should treat this as "report to support".
+ */
+export enum ErrorCategory {
+  VALIDATION = "VALIDATION",
+  UNSUPPORTED_ROUTE = "UNSUPPORTED_ROUTE",
+  INSUFFICIENT_LIQUIDITY = "INSUFFICIENT_LIQUIDITY",
+  PROVIDER_FAILURE = "PROVIDER_FAILURE",
+  RATE_LIMITED = "RATE_LIMITED",
+  UNAVAILABLE = "UNAVAILABLE",
+  INTERNAL = "INTERNAL",
+}
+
+/**
+ * Map category → default HTTP status.
+ */
+export function categoryToHttpStatus(category: ErrorCategory): number {
+  switch (category) {
+    case ErrorCategory.VALIDATION:
+      return 400;
+    case ErrorCategory.UNSUPPORTED_ROUTE:
+      return 404;
+    case ErrorCategory.RATE_LIMITED:
+      return 429;
+    case ErrorCategory.INSUFFICIENT_LIQUIDITY:
+      return 422;
+    case ErrorCategory.INTERNAL:
+      return 500;
+    case ErrorCategory.PROVIDER_FAILURE:
+      return 502;
+    case ErrorCategory.UNAVAILABLE:
+      return 503;
+  }
+}
+
+// -------------------------------------------------------------------------------------------------
+// The class
+// -------------------------------------------------------------------------------------------------
+
+export interface CapabilityErrorInput {
+  /** Code in the form `CAPABILITY_<CAP>_<TYPE>`. See CONVENTIONS.md §6. */
+  code: string;
+  category: ErrorCategory;
+  message: string;
+  provider?: string;
+  details?: Record<string, unknown>;
+  /** Override the default HTTP status for this category. Rare; useful for retry-after semantics. */
+  httpStatus?: number;
+  /** Wrapped underlying cause (e.g. an ethers error). Preserved for logs, not exposed over the wire. */
+  cause?: unknown;
+}
+
+export class CapabilityError extends Error {
+  public readonly code: string;
+  public readonly category: ErrorCategory;
+  public readonly provider?: string;
+  public readonly details?: Record<string, unknown>;
+  public readonly httpStatus: number;
+  public readonly cause?: unknown;
+
+  constructor(input: CapabilityErrorInput) {
+    super(input.message);
+    this.name = "CapabilityError";
+    this.code = input.code;
+    this.category = input.category;
+    this.provider = input.provider;
+    this.details = input.details;
+    this.httpStatus = input.httpStatus ?? categoryToHttpStatus(input.category);
+    this.cause = input.cause;
+
+    // Preserve the stack as if thrown from the call site, not from this constructor.
+    if (typeof Error.captureStackTrace === "function") {
+      Error.captureStackTrace(this, CapabilityError);
+    }
+  }
+
+  /**
+   * Serialise into the wire format embedded in `CapabilityResponse.error`.
+   * `cause` is intentionally omitted from the wire format — keep upstream errors in logs only.
+   */
+  toSerialized(): SerializedCapabilityError {
+    return {
+      code: this.code,
+      category: this.category,
+      message: this.message,
+      ...(this.provider && { provider: this.provider }),
+      ...(this.details && { details: this.details }),
+      httpStatus: this.httpStatus,
+    };
+  }
+
+  /**
+   * Useful in tests / type guards. `error instanceof CapabilityError` fails across module
+   * boundaries when multiple copies of the class exist; this is a structural check.
+   */
+  static is(error: unknown): error is CapabilityError {
+    return (
+      error instanceof CapabilityError ||
+      (typeof error === "object" &&
+        error !== null &&
+        (error as { name?: string }).name === "CapabilityError" &&
+        typeof (error as { code?: unknown }).code === "string" &&
+        typeof (error as { category?: unknown }).category === "string")
+    );
+  }
+
+  // -----------------------------------------------------------------------------------------------
+  // Factory methods — preferred way to construct common errors
+  // -----------------------------------------------------------------------------------------------
+
+  /**
+   * No provider supports the requested route. Use when `policy.rank` returns 0 candidates or
+   * every candidate fails `supportsRoute`.
+   */
+  static unsupportedRoute(input: {
+    capability: string;
+    chainId: number;
+    attempted: string[];
+    fromAsset?: string;
+    toAsset?: string;
+  }): CapabilityError {
+    return new CapabilityError({
+      code: `CAPABILITY_${input.capability.toUpperCase()}_UNSUPPORTED_ROUTE`,
+      category: ErrorCategory.UNSUPPORTED_ROUTE,
+      message: `No provider supports ${input.capability} on chain ${input.chainId}${
+        input.fromAsset && input.toAsset ? ` for ${input.fromAsset} → ${input.toAsset}` : ""
+      }. Attempted: ${input.attempted.join(", ") || "(none)"}.`,
+      details: {
+        capability: input.capability,
+        chainId: input.chainId,
+        attempted: input.attempted,
+        ...(input.fromAsset && { fromAsset: input.fromAsset }),
+        ...(input.toAsset && { toAsset: input.toAsset }),
+      },
+    });
+  }
+
+  /**
+   * All ranked providers were attempted and each failed. Carries the per-provider error list
+   * so the FE / logs can diagnose without N round-trips.
+   */
+  static allProvidersFailed(input: {
+    capability: string;
+    attempts: Array<{ provider: string; error: string }>;
+  }): CapabilityError {
+    return new CapabilityError({
+      code: `CAPABILITY_${input.capability.toUpperCase()}_ALL_PROVIDERS_FAILED`,
+      category: ErrorCategory.UNAVAILABLE,
+      message: `All ${input.capability} providers failed. Attempts: ${input.attempts
+        .map((a) => `${a.provider}: ${a.error}`)
+        .join(" | ")}`,
+      details: {
+        capability: input.capability,
+        attempts: input.attempts,
+      },
+    });
+  }
+
+  /**
+   * Capability isn't implemented (yet) for this chain/path. Used by stub adapters
+   * (`BaseStakingProviderAdapter` etc.) and by the registry when no provider has `enabled: true`.
+   */
+  static unavailable(message: string, details?: Record<string, unknown>): CapabilityError {
+    return new CapabilityError({
+      code: "CAPABILITY_UNAVAILABLE",
+      category: ErrorCategory.UNAVAILABLE,
+      message,
+      details,
+    });
+  }
+
+  /**
+   * Input validation failed (Zod, manual checks). The `details.errors` should carry a
+   * structured list of field-level violations for the FE to render.
+   */
+  static validation(input: {
+    capability?: string;
+    message: string;
+    errors?: unknown;
+  }): CapabilityError {
+    const cap = input.capability ?? "REQUEST";
+    return new CapabilityError({
+      code: `CAPABILITY_${cap.toUpperCase()}_VALIDATION_FAILED`,
+      category: ErrorCategory.VALIDATION,
+      message: input.message,
+      details: input.errors ? { errors: input.errors } : undefined,
+    });
+  }
+
+  /**
+   * Wrap a provider-level failure. The original error goes to `cause` (logs only), not over wire.
+   */
+  static providerFailure(input: {
+    capability: string;
+    provider: string;
+    message: string;
+    cause?: unknown;
+    details?: Record<string, unknown>;
+  }): CapabilityError {
+    return new CapabilityError({
+      code: `CAPABILITY_${input.capability.toUpperCase()}_PROVIDER_FAILURE`,
+      category: ErrorCategory.PROVIDER_FAILURE,
+      message: input.message,
+      provider: input.provider,
+      details: input.details,
+      cause: input.cause,
+    });
+  }
+
+  /**
+   * Rate-limit hit. `retryAfterMs` is optional; set it to drive a `Retry-After` header.
+   */
+  static rateLimited(input: {
+    capability: string;
+    provider?: string;
+    retryAfterMs?: number;
+  }): CapabilityError {
+    return new CapabilityError({
+      code: `CAPABILITY_${input.capability.toUpperCase()}_RATE_LIMITED`,
+      category: ErrorCategory.RATE_LIMITED,
+      message: `Rate limit hit on ${input.capability}${
+        input.provider ? ` (provider: ${input.provider})` : ""
+      }.`,
+      provider: input.provider,
+      details: input.retryAfterMs ? { retryAfterMs: input.retryAfterMs } : undefined,
+    });
+  }
+
+  /**
+   * Internal error — for unexpected bugs. Avoid in normal flow; this 500s the request and pages oncall.
+   */
+  static internal(message: string, cause?: unknown): CapabilityError {
+    return new CapabilityError({
+      code: "CAPABILITY_INTERNAL_ERROR",
+      category: ErrorCategory.INTERNAL,
+      message,
+      cause,
+    });
+  }
+}

--- a/shared/capability/index.ts
+++ b/shared/capability/index.ts
@@ -1,0 +1,50 @@
+/**
+ * @panorama/capability — public API.
+ *
+ * Consumers (backend services) import from this entry point. See CONVENTIONS.md.
+ */
+
+// Envelope: request/response shapes, primitives, transaction, type guards, builders.
+export type {
+  Address,
+  ChainId,
+  WeiString,
+  Uuid,
+  ProviderInfo,
+  Transaction,
+  CapabilityRequest,
+  CapabilitySuccessResponse,
+  CapabilityErrorResponse,
+  CapabilityResponse,
+  SerializedCapabilityError,
+  BuildSuccessInput,
+  BuildErrorInput,
+} from "./envelope.types";
+
+export { isSuccess, isError, buildSuccess, buildError } from "./envelope.types";
+
+// Errors: taxonomy, class, factories.
+export { ErrorCategory, CapabilityError, categoryToHttpStatus } from "./errors";
+
+// Provider metadata: shape + capability slug + base provider interface.
+export type {
+  CapabilitySlug,
+  ProviderMetadata,
+  ICapabilityProvider,
+  ProviderHealth,
+} from "./provider.types";
+
+export {
+  CAPABILITY_SLUGS,
+  isCapabilitySlug,
+  validateProviderMetadata,
+} from "./provider.types";
+
+// Availability: discovery schema for /v1/capability/_discovery.
+export type {
+  ProviderAvailability,
+  CapabilityAvailability,
+  AvailabilityMap,
+} from "./availability.types";
+
+export { buildAvailabilityMap } from "./availability.types";

--- a/shared/capability/package-lock.json
+++ b/shared/capability/package-lock.json
@@ -1,0 +1,1851 @@
+{
+  "name": "@panorama/capability",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@panorama/capability",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^20.11.0",
+        "typescript": "^5.4.0",
+        "vitest": "^1.6.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
+      "integrity": "sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.4.tgz",
+      "integrity": "sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.4.tgz",
+      "integrity": "sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.4.tgz",
+      "integrity": "sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.4.tgz",
+      "integrity": "sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.4.tgz",
+      "integrity": "sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.4.tgz",
+      "integrity": "sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.4.tgz",
+      "integrity": "sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.4.tgz",
+      "integrity": "sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.4.tgz",
+      "integrity": "sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.4.tgz",
+      "integrity": "sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.4.tgz",
+      "integrity": "sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.4.tgz",
+      "integrity": "sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.4.tgz",
+      "integrity": "sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.4.tgz",
+      "integrity": "sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.4.tgz",
+      "integrity": "sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.4.tgz",
+      "integrity": "sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.4.tgz",
+      "integrity": "sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.4.tgz",
+      "integrity": "sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.4.tgz",
+      "integrity": "sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.4.tgz",
+      "integrity": "sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.4.tgz",
+      "integrity": "sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.4.tgz",
+      "integrity": "sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.4.tgz",
+      "integrity": "sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
+      "integrity": "sha512-jXL+9+ZNIJKruofqXuuTClf44eSpcHlgj3CiuNihUF3Ioujtmc0zIa3UJOW5RjDK1YLBJZnWBlPuqhYycLioog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-1.6.1.tgz",
+      "integrity": "sha512-3nSnYXkVkf3mXFfE7vVyPmi3Sazhb/2cfZGGs0JRzFsPFvAMBEcrweV1V1GsrstdXeKCTXlJbvnQwGWgEIHmOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "1.6.1",
+        "p-limit": "^5.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-1.6.1.tgz",
+      "integrity": "sha512-WvidQuWAzU2p95u8GAKlRMqMyN1yOJkGHnx3M1PL9Raf7AQ1kwLKg04ADlCa3+OXUZE7BceOhVZiuWAbzCKcUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-1.6.1.tgz",
+      "integrity": "sha512-MGcMmpGkZebsMZhbQKkAf9CX5zGvjkBTqf8Zx3ApYWXr3wG+QvEu2eXWfnIIWYSJExIp4V9FCKDEeygzkYrXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^2.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-1.6.1.tgz",
+      "integrity": "sha512-jOrrUvXM4Av9ZWiG1EajNto0u96kWAhJ1LmPmJhXXQx/32MecEKd10pOLYgS2BQx1TgkGhloPU1ArDW2vvaY6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "diff-sequences": "^29.6.3",
+        "estree-walker": "^3.0.3",
+        "loupe": "^2.3.7",
+        "pretty-format": "^29.7.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/execa": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
+      "integrity": "sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^8.0.1",
+        "human-signals": "^5.0.0",
+        "is-stream": "^3.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^5.1.0",
+        "onetime": "^6.0.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/human-signals": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
+      "integrity": "sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16.17.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/local-pkg": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.1.tgz",
+      "integrity": "sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mlly": "^1.7.3",
+        "pkg-types": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mimic-fn": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+      "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
+      "integrity": "sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^4.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm-run-path/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+      "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.60.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.4.tgz",
+      "integrity": "sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.4",
+        "@rollup/rollup-android-arm64": "4.60.4",
+        "@rollup/rollup-darwin-arm64": "4.60.4",
+        "@rollup/rollup-darwin-x64": "4.60.4",
+        "@rollup/rollup-freebsd-arm64": "4.60.4",
+        "@rollup/rollup-freebsd-x64": "4.60.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.4",
+        "@rollup/rollup-linux-arm64-musl": "4.60.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.4",
+        "@rollup/rollup-linux-loong64-musl": "4.60.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-gnu": "4.60.4",
+        "@rollup/rollup-linux-x64-musl": "4.60.4",
+        "@rollup/rollup-openbsd-x64": "4.60.4",
+        "@rollup/rollup-openharmony-arm64": "4.60.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.4",
+        "@rollup/rollup-win32-x64-gnu": "4.60.4",
+        "@rollup/rollup-win32-x64-msvc": "4.60.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup/node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-final-newline": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+      "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-2.1.1.tgz",
+      "integrity": "sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.8.4.tgz",
+      "integrity": "sha512-i11VH5gS6IFeLY3gMBQ00/MmLncVP7JLXOw1vlgkytLmJK7QnEr7NXf0LBdxfmNPAeyetukOk0bOYrJrFGjYJQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+      "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-1.6.1.tgz",
+      "integrity": "sha512-YAXkfvGtuTzwWbDSACdJSg4A4DZiAqckWe90Zapc/sEX3XvHcw1NdurM/6od8J207tSDqNbSsgdCacBgvJKFuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-1.6.1.tgz",
+      "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "1.6.1",
+        "@vitest/runner": "1.6.1",
+        "@vitest/snapshot": "1.6.1",
+        "@vitest/spy": "1.6.1",
+        "@vitest/utils": "1.6.1",
+        "acorn-walk": "^8.3.2",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "execa": "^8.0.1",
+        "local-pkg": "^0.5.0",
+        "magic-string": "^0.30.5",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.5.0",
+        "strip-literal": "^2.0.0",
+        "tinybench": "^2.5.1",
+        "tinypool": "^0.8.3",
+        "vite": "^5.0.0",
+        "vite-node": "1.6.1",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "1.6.1",
+        "@vitest/ui": "1.6.1",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/shared/capability/package.json
+++ b/shared/capability/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@panorama/capability",
+  "version": "0.1.0",
+  "description": "Shared capability foundation: envelope, errors, registry, policy, chains. Source of truth consumed by every backend service.",
+  "private": true,
+  "main": "index.ts",
+  "types": "index.ts",
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "typescript": "^5.4.0",
+    "vitest": "^1.6.0"
+  }
+}

--- a/shared/capability/provider.types.ts
+++ b/shared/capability/provider.types.ts
@@ -1,0 +1,189 @@
+/**
+ * Provider metadata + base provider interface.
+ *
+ * Every adapter implements `ICapabilityProvider` (extended by per-capability ports like
+ * `ISwapProvider`, `IStakingProvider`) and declares itself via `metadata: ProviderMetadata`.
+ *
+ * The metadata is what the Registry, Policy, Health tracker, and Discovery endpoint introspect.
+ *
+ * See CONVENTIONS.md §5 (provider naming) and ADR 002 §"Five-layer pattern".
+ */
+
+import type { ChainId } from "./envelope.types";
+
+// -------------------------------------------------------------------------------------------------
+// Capability slug — the closed set
+// -------------------------------------------------------------------------------------------------
+
+/**
+ * Canonical capability slugs. Adding one requires an ADR (see ADR 003).
+ */
+export const CAPABILITY_SLUGS = [
+  "swap",
+  "lending",
+  "staking",
+  "liquidity",
+  "bridge",
+  "automation",
+  "auth",
+] as const;
+
+export type CapabilitySlug = (typeof CAPABILITY_SLUGS)[number];
+
+export function isCapabilitySlug(value: unknown): value is CapabilitySlug {
+  return typeof value === "string" && (CAPABILITY_SLUGS as readonly string[]).includes(value);
+}
+
+// -------------------------------------------------------------------------------------------------
+// Metadata that every provider declares
+// -------------------------------------------------------------------------------------------------
+
+export interface ProviderMetadata {
+  /** Provider name — lowercase ASCII. See CONVENTIONS.md §5. */
+  name: string;
+
+  /** Which capability this provider serves. Must be one of the closed set. */
+  capability: CapabilitySlug;
+
+  /** Chains on which this provider can operate. The Registry uses this for `listByChain`. */
+  supportedChains: ChainId[];
+
+  /** Free-form feature tags (e.g. `['stETH', 'wstETH']`, `['cross-chain']`). */
+  features?: string[];
+
+  /** SemVer of the adapter implementation (not the upstream protocol). */
+  version: string;
+
+  /**
+   * When `false`, the provider is built and registered but the Registry skips it on `listByChain`
+   * unless explicitly opted in. Default `true`.
+   *
+   * Used by stub adapters (e.g. `BaseStakingProviderAdapter`) that ship structurally complete
+   * but with `throw CapabilityError.unavailable(...)` on every method.
+   */
+  enabled?: boolean;
+}
+
+// -------------------------------------------------------------------------------------------------
+// Health probe shape
+// -------------------------------------------------------------------------------------------------
+
+/**
+ * Result of `provider.healthCheck()`. Used by the `ProviderHealthTracker` (card #209) to filter
+ * unhealthy providers out of `listByChain`.
+ */
+export interface ProviderHealth {
+  healthy: boolean;
+  /** Round-trip latency of the probe in ms. */
+  latencyMs?: number;
+  /** Human-readable reason if `healthy: false`. */
+  reason?: string;
+  /** When this probe was taken. */
+  checkedAt: string; // ISO 8601
+}
+
+// -------------------------------------------------------------------------------------------------
+// Base provider interface
+// -------------------------------------------------------------------------------------------------
+
+/**
+ * The shape every provider in the system shares. Per-capability ports extend this with
+ * domain-specific methods.
+ *
+ * **Subtype convention:** per-capability port name is `I<Cap>Provider`. Each lives in the owning
+ * service's `domain/ports/<cap>.provider.port.ts` and is imported by adapters there.
+ *
+ * @example
+ *   // in lido-service/src/domain/ports/staking.provider.port.ts
+ *   export interface IStakingProvider extends ICapabilityProvider {
+ *     getPosition(addr: string, chainId: ChainId): Promise<StakingPosition>;
+ *     prepareStake(req: PrepareStakeRequest): Promise<Transaction[]>;
+ *   }
+ */
+export interface ICapabilityProvider {
+  /** Provider name. Must match `metadata.name`. */
+  readonly name: string;
+
+  /** Full declaration of what this provider is/does. */
+  readonly metadata: ProviderMetadata;
+
+  /**
+   * Optional health probe. If absent, the provider is treated as always healthy.
+   * Implementations should be lightweight — this is polled at ~30s intervals.
+   */
+  healthCheck?(): Promise<ProviderHealth>;
+}
+
+// -------------------------------------------------------------------------------------------------
+// Metadata validation
+// -------------------------------------------------------------------------------------------------
+
+export interface ValidationOk {
+  ok: true;
+}
+export interface ValidationErr {
+  ok: false;
+  errors: string[];
+}
+export type ValidationResult = ValidationOk | ValidationErr;
+
+/**
+ * Validate a `ProviderMetadata` object. Used by the Registry on `register()` and by the config
+ * loader (`registry.loader.ts`, card #205) when populating from JSON.
+ *
+ * Returns a structured result rather than throwing so callers can aggregate errors when loading
+ * many providers from config.
+ */
+export function validateProviderMetadata(m: unknown): ValidationResult {
+  const errors: string[] = [];
+
+  if (typeof m !== "object" || m === null) {
+    return { ok: false, errors: ["metadata must be an object"] };
+  }
+
+  const meta = m as Partial<ProviderMetadata>;
+
+  if (typeof meta.name !== "string" || meta.name.length === 0) {
+    errors.push("name must be a non-empty string");
+  } else if (meta.name !== meta.name.toLowerCase()) {
+    errors.push(`name must be lowercase (got "${meta.name}")`);
+  } else if (!/^[a-z][a-z0-9-]*$/.test(meta.name)) {
+    errors.push(`name must match /^[a-z][a-z0-9-]*$/ (got "${meta.name}")`);
+  }
+
+  if (typeof meta.capability !== "string" || !isCapabilitySlug(meta.capability)) {
+    errors.push(
+      `capability must be one of ${CAPABILITY_SLUGS.join("|")} (got ${JSON.stringify(meta.capability)})`
+    );
+  }
+
+  if (!Array.isArray(meta.supportedChains)) {
+    errors.push("supportedChains must be an array");
+  } else {
+    if (meta.supportedChains.length === 0) {
+      errors.push("supportedChains must have at least one chain id");
+    }
+    const bad = meta.supportedChains.filter(
+      (c) => !Number.isInteger(c) || (c as number) <= 0
+    );
+    if (bad.length > 0) {
+      errors.push(`supportedChains contains non-positive-integer entries: ${JSON.stringify(bad)}`);
+    }
+  }
+
+  if (typeof meta.version !== "string" || !/^\d+\.\d+\.\d+/.test(meta.version)) {
+    errors.push(`version must be a SemVer-ish string (got ${JSON.stringify(meta.version)})`);
+  }
+
+  if (meta.features !== undefined) {
+    if (!Array.isArray(meta.features) || meta.features.some((f) => typeof f !== "string")) {
+      errors.push("features, when present, must be an array of strings");
+    }
+  }
+
+  if (meta.enabled !== undefined && typeof meta.enabled !== "boolean") {
+    errors.push("enabled, when present, must be boolean");
+  }
+
+  return errors.length === 0 ? { ok: true } : { ok: false, errors };
+}

--- a/shared/capability/tsconfig.json
+++ b/shared/capability/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "noEmit": true,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/shared/capability/vitest.config.ts
+++ b/shared/capability/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    include: ["**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html"],
+      include: ["*.ts"],
+      exclude: ["__tests__/**", "*.config.ts", "index.ts"],
+    },
+  },
+});


### PR DESCRIPTION
## Cards

- Closes Panorama-Block/panoramablock-backend#199 — Define shared capability naming conventions
- Closes Panorama-Block/panoramablock-backend#200 — Define shared request-response envelope
- Closes Panorama-Block/panoramablock-backend#201 — Define capability error taxonomy
- Closes Panorama-Block/panoramablock-backend#202 — Define provider metadata schema
- Closes Panorama-Block/panoramablock-backend#203 — Define capability availability schema

## Mudanças

Cria `backend/shared/capability/` — o pacote `@panorama/capability` que vira a fonte da verdade consumida por todos os 6 backend services no padrão capability-first (ADR 002).

### Arquivos criados

- `CONVENTIONS.md` — naming, layout, error code pattern, HTTP namespace, regras de import
- `envelope.types.ts` — `CapabilityRequest<T>`, `CapabilityResponse<T>`, type guards (`isSuccess`/`isError`), builders (`buildSuccess`/`buildError`), primitives (`Address`, `ChainId`, `WeiString`, `Transaction`, `ProviderInfo`)
- `errors.ts` — `CapabilityError` class, `ErrorCategory` enum (VALIDATION, UNSUPPORTED_ROUTE, INSUFFICIENT_LIQUIDITY, PROVIDER_FAILURE, RATE_LIMITED, UNAVAILABLE, INTERNAL), `categoryToHttpStatus`, factory methods (`unsupportedRoute`, `allProvidersFailed`, `validation`, `providerFailure`, `rateLimited`, `internal`, `unavailable`)
- `provider.types.ts` — `CapabilitySlug` closed set, `ProviderMetadata`, `ICapabilityProvider` base interface, `ProviderHealth`, `validateProviderMetadata` retornando `Result` estruturado
- `availability.types.ts` — wire shape do `/v1/capability/_discovery` + `buildAvailabilityMap` puro (usado depois pelo handler do card #207)
- `index.ts` — public API (re-exports)

### Tooling

- Standalone npm package (`@panorama/capability@0.1.0`, private)
- TypeScript strict, `noEmit` (só type-check; consumers via tsconfig paths)
- Vitest pra runtime tests
- 68 unit tests passando (envelope: 10, provider: 25, errors: 20, availability: 13)
- `npm run typecheck` clean

## Por que agora

Bloco 2 da trilha do Hugo. Bloco 1 (ADRs #74–#78) já está no PR https://github.com/Panorama-Block/execution-layer/pull/90. Sem este pacote os outros devs não conseguem começar suas capabilities (Rizzi #229+, Marcos #239+, Coletto #257+).

## Como consumir (em PRs subsequentes)

Cada service que consumir adiciona em seu `tsconfig.json`:

\`\`\`jsonc
{
  "compilerOptions": {
    "paths": {
      "@panorama/capability": ["../shared/capability/index.ts"],
      "@panorama/capability/*": ["../shared/capability/*"]
    }
  }
}
\`\`\`

E importa:

\`\`\`typescript
import { CapabilityError, ErrorCategory, type ICapabilityProvider } from "@panorama/capability";
\`\`\`

Os PRs de cada capability (Staking #244+, Swap #229+, Lending #238+, etc.) já preveem esse passo.

## Camada / DoD

- [x] Testes locais passando (`npm test` em `shared/capability/` — 68 ok)
- [x] Typecheck (`npm run typecheck` — clean)
- [x] Sem mudanças em diretórios fora do meu escopo (apenas `shared/capability/`)
- [x] Backward-compat preservada (pacote novo, não substitui nada existente)
- [x] Doc (`CONVENTIONS.md` próprio + linkado nos ADRs do PR exec-layer#90)
- [ ] Review approved por par (Coletto primário, Rizzi secundário)

## Notas para review

- O `Provider Registry` (cards #204–#210) e `Chain Onboarding` (cards #211–#214) — que **usam** os tipos deste PR — virão em PRs separados desta mesma trilha.
- `CapabilitySlug` inclui `'auth'` apesar de Auth ter sido movida pra trilha do Marcos — o slug é uma constante do vocabulário, não muda de dono.
- `validateProviderMetadata` retorna `Result` estruturado em vez de jogar erro pra que o config loader (#205) possa agregar erros de múltiplos providers numa única mensagem.
- `buildAvailabilityMap` é puro / determinístico — os aspectos runtime (RPC probing, rolling p95) virão no `ProviderHealthTracker` (#209).