### PR TITLE
[#204–#210] Provider Registry, Policy, Health, Discovery (Bloco 3)

### DIFF
--- a/shared/capability/__tests__/health.test.ts
+++ b/shared/capability/__tests__/health.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi } from "vitest";
+
+import {
+  ProviderHealthTracker,
+  type HealthScheduler,
+} from "../health";
+import type { ICapabilityProvider, ProviderHealth } from "../provider.types";
+
+function makeProvider(
+  name: string,
+  healthCheck?: () => Promise<ProviderHealth>
+): ICapabilityProvider {
+  return {
+    name,
+    metadata: {
+      name,
+      capability: "swap",
+      supportedChains: [1],
+      version: "1.0.0",
+    },
+    ...(healthCheck && { healthCheck }),
+  };
+}
+
+/** Manual scheduler: only fires when test calls `tick()`. */
+function manualScheduler() {
+  let cb: (() => void) | null = null;
+  const scheduler: HealthScheduler = {
+    start(c) {
+      cb = c;
+      return {
+        stop() {
+          cb = null;
+        },
+      };
+    },
+  };
+  return { scheduler, tick: () => cb?.() };
+}
+
+describe("ProviderHealthTracker — provider without healthCheck", () => {
+  it("is always healthy (graceful)", async () => {
+    const tracker = new ProviderHealthTracker();
+    tracker.track(makeProvider("uniswap"));
+    expect(tracker.isHealthy("uniswap")).toBe(true);
+    await tracker.probeAll();
+    expect(tracker.isHealthy("uniswap")).toBe(true);
+  });
+
+  it("snapshot is empty for providers without probes", async () => {
+    const tracker = new ProviderHealthTracker();
+    tracker.track(makeProvider("uniswap"));
+    await tracker.probeAll();
+    expect(tracker.snapshot().size).toBe(0);
+  });
+});
+
+describe("ProviderHealthTracker — happy probe", () => {
+  it("records latency + marks healthy", async () => {
+    const probe = vi.fn(async () => ({
+      healthy: true,
+      latencyMs: 42,
+      checkedAt: "2026-05-22T00:00:00Z",
+    }));
+    const tracker = new ProviderHealthTracker({ now: () => new Date("2026-05-22T00:00:00Z") });
+    tracker.track(makeProvider("uniswap", probe));
+    await tracker.probeAll();
+    expect(probe).toHaveBeenCalledOnce();
+    expect(tracker.isHealthy("uniswap")).toBe(true);
+    const snap = tracker.snapshot().get("uniswap");
+    expect(snap?.healthy).toBe(true);
+    expect(snap?.latencyMs).toBe(42);
+  });
+
+  it("p95 latency populates after enough samples", async () => {
+    const latencies = [10, 12, 15, 20, 30, 50, 100, 200, 500, 1000];
+    let i = 0;
+    const probe = async () => ({
+      healthy: true,
+      latencyMs: latencies[i++ % latencies.length] as number,
+      checkedAt: "x",
+    });
+    const tracker = new ProviderHealthTracker();
+    tracker.track(makeProvider("u", probe));
+    for (let n = 0; n < 10; n++) await tracker.probeAll();
+    const report = tracker.report().find((r) => r.name === "u");
+    expect(report?.healthy).toBe(true);
+    expect(report?.latencyP95Ms).toBeGreaterThan(200);
+  });
+});
+
+describe("ProviderHealthTracker — failure threshold", () => {
+  it("requires N consecutive failures (default 3) to flip unhealthy", async () => {
+    let nextHealthy = false;
+    const probe = vi.fn(async () => ({
+      healthy: nextHealthy,
+      latencyMs: 5,
+      checkedAt: "x",
+    }));
+    const tracker = new ProviderHealthTracker({ unhealthyAfter: 3 });
+    tracker.track(makeProvider("u", probe));
+
+    await tracker.probeAll(); // fail #1
+    expect(tracker.isHealthy("u")).toBe(true);
+    await tracker.probeAll(); // fail #2
+    expect(tracker.isHealthy("u")).toBe(true);
+    await tracker.probeAll(); // fail #3 → unhealthy
+    expect(tracker.isHealthy("u")).toBe(false);
+
+    nextHealthy = true;
+    await tracker.probeAll(); // success
+    expect(tracker.isHealthy("u")).toBe(true);
+  });
+
+  it("one success resets consecutiveFailures", async () => {
+    let pattern = [false, false, true, false, false]; // success at #3 should reset counter
+    let i = 0;
+    const probe = async () => ({
+      healthy: pattern[i++] ?? false,
+      checkedAt: "x",
+      latencyMs: 1,
+    });
+    const tracker = new ProviderHealthTracker({ unhealthyAfter: 3 });
+    tracker.track(makeProvider("u", probe));
+    await tracker.probeAll();
+    await tracker.probeAll();
+    await tracker.probeAll(); // success
+    expect(tracker.isHealthy("u")).toBe(true);
+    await tracker.probeAll();
+    await tracker.probeAll();
+    expect(tracker.isHealthy("u")).toBe(true); // only 2 failures after reset
+  });
+});
+
+describe("ProviderHealthTracker — exceptions in healthCheck", () => {
+  it("treats thrown error as unhealthy probe + calls onError", async () => {
+    const onError = vi.fn();
+    const tracker = new ProviderHealthTracker({ unhealthyAfter: 1, onError });
+    tracker.track(
+      makeProvider("u", async () => {
+        throw new Error("rpc unreachable");
+      })
+    );
+    await tracker.probeAll();
+    expect(tracker.isHealthy("u")).toBe(false);
+    expect(onError).toHaveBeenCalledOnce();
+    const snap = tracker.snapshot().get("u");
+    expect(snap?.healthy).toBe(false);
+    expect(snap?.reason).toBe("rpc unreachable");
+  });
+});
+
+describe("ProviderHealthTracker — manual marks", () => {
+  it("markUnhealthy flips state without a probe", () => {
+    const tracker = new ProviderHealthTracker({ unhealthyAfter: 3 });
+    tracker.track(makeProvider("u", async () => ({ healthy: true, checkedAt: "x" })));
+    tracker.markUnhealthy("u", "manually disabled");
+    expect(tracker.isHealthy("u")).toBe(false);
+    const snap = tracker.snapshot().get("u");
+    expect(snap?.reason).toBe("manually disabled");
+  });
+
+  it("markHealthy resets counters", async () => {
+    const tracker = new ProviderHealthTracker({ unhealthyAfter: 1 });
+    tracker.track(
+      makeProvider("u", async () => ({ healthy: false, checkedAt: "x" }))
+    );
+    await tracker.probeAll();
+    expect(tracker.isHealthy("u")).toBe(false);
+    tracker.markHealthy("u");
+    expect(tracker.isHealthy("u")).toBe(true);
+  });
+
+  it("markUnhealthy on untracked provider is a silent no-op", () => {
+    const tracker = new ProviderHealthTracker();
+    expect(() => tracker.markUnhealthy("ghost", "x")).not.toThrow();
+  });
+});
+
+describe("ProviderHealthTracker — scheduler integration", () => {
+  it("start fires probeAll on each tick", async () => {
+    const { scheduler, tick } = manualScheduler();
+    const probe = vi.fn(async () => ({ healthy: true, checkedAt: "x", latencyMs: 1 }));
+    const tracker = new ProviderHealthTracker({ scheduler });
+    tracker.track(makeProvider("u", probe));
+    tracker.start();
+
+    tick();
+    await Promise.resolve(); // let microtasks flush
+    await Promise.resolve();
+    expect(probe).toHaveBeenCalledOnce();
+
+    tick();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(probe).toHaveBeenCalledTimes(2);
+
+    tracker.stop();
+    tick();
+    await Promise.resolve();
+    expect(probe).toHaveBeenCalledTimes(2); // stopped — no more ticks
+  });
+
+  it("start is idempotent", () => {
+    const { scheduler } = manualScheduler();
+    const startSpy = vi.spyOn(scheduler, "start");
+    const tracker = new ProviderHealthTracker({ scheduler });
+    tracker.start();
+    tracker.start();
+    expect(startSpy).toHaveBeenCalledOnce();
+  });
+});
+
+describe("ProviderHealthTracker — untracked providers", () => {
+  it("isHealthy returns true for unknown name (no data = optimistic)", () => {
+    const tracker = new ProviderHealthTracker();
+    expect(tracker.isHealthy("ghost")).toBe(true);
+  });
+
+  it("untrack removes from state and snapshot", async () => {
+    const tracker = new ProviderHealthTracker();
+    tracker.track(makeProvider("u", async () => ({ healthy: true, checkedAt: "x" })));
+    await tracker.probeAll();
+    expect(tracker.snapshot().has("u")).toBe(true);
+    tracker.untrack("u");
+    expect(tracker.snapshot().has("u")).toBe(false);
+  });
+});
+
+describe("ProviderHealthTracker — report", () => {
+  it("returns one entry per tracked provider", async () => {
+    const tracker = new ProviderHealthTracker();
+    tracker.track(makeProvider("u1", async () => ({ healthy: true, checkedAt: "x", latencyMs: 5 })));
+    tracker.track(makeProvider("u2"));
+    await tracker.probeAll();
+    const report = tracker.report();
+    expect(report.map((r) => r.name).sort()).toEqual(["u1", "u2"]);
+    expect(report.find((r) => r.name === "u1")?.latencyP95Ms).toBe(5);
+    expect(report.find((r) => r.name === "u2")?.latencyP95Ms).toBeUndefined();
+  });
+});

--- a/shared/capability/__tests__/policy.test.ts
+++ b/shared/capability/__tests__/policy.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect, vi } from "vitest";
+
+import {
+  ChainAssetPriorityPolicy,
+  fallbackInvoke,
+  type PolicyContext,
+} from "../policy";
+import { CapabilityError, ErrorCategory } from "../errors";
+import type { ICapabilityProvider } from "../provider.types";
+
+interface SwapP extends ICapabilityProvider {
+  tag: string;
+}
+
+function provider(name: string): SwapP {
+  return {
+    name,
+    metadata: {
+      name,
+      capability: "swap",
+      supportedChains: [1, 8453],
+      version: "1.0.0",
+    },
+    tag: name,
+  };
+}
+
+const uniswap = provider("uniswap");
+const aerodrome = provider("aerodrome");
+const thirdweb = provider("thirdweb");
+const utapi = provider("uniswap-trading-api");
+
+const allProviders = [uniswap, aerodrome, thirdweb, utapi];
+
+const baseSameChainCtx: PolicyContext = { chainId: 8453 };
+const ethSameChainCtx: PolicyContext = { chainId: 1 };
+const crossChainCtx: PolicyContext = { chainId: 1, destinationChainId: 137 };
+
+describe("ChainAssetPriorityPolicy — flat per-chain config", () => {
+  const policy = new ChainAssetPriorityPolicy({
+    "8453": ["aerodrome", "uniswap-trading-api", "uniswap", "thirdweb"],
+    "1": ["uniswap-trading-api", "uniswap", "thirdweb"],
+    "default-cross-chain": ["thirdweb", "uniswap-trading-api", "uniswap"],
+  });
+
+  it("ranks per config for Base same-chain", () => {
+    const r = policy.rank(allProviders, baseSameChainCtx).map((p) => p.name);
+    expect(r).toEqual(["aerodrome", "uniswap-trading-api", "uniswap", "thirdweb"]);
+  });
+
+  it("ranks per config for Eth same-chain (aerodrome unmentioned → last, stable)", () => {
+    const r = policy.rank(allProviders, ethSameChainCtx).map((p) => p.name);
+    expect(r).toEqual(["uniswap-trading-api", "uniswap", "thirdweb", "aerodrome"]);
+  });
+
+  it("uses default-cross-chain when destinationChainId differs", () => {
+    const r = policy.rank(allProviders, crossChainCtx).map((p) => p.name);
+    expect(r).toEqual(["thirdweb", "uniswap-trading-api", "uniswap", "aerodrome"]);
+  });
+
+  it("returns providers unchanged when chain not in config", () => {
+    const r = policy.rank(allProviders, { chainId: 137 }).map((p) => p.name);
+    expect(r).toEqual(["uniswap", "aerodrome", "thirdweb", "uniswap-trading-api"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const input = [...allProviders];
+    policy.rank(input, baseSameChainCtx);
+    expect(input.map((p) => p.name)).toEqual([
+      "uniswap",
+      "aerodrome",
+      "thirdweb",
+      "uniswap-trading-api",
+    ]);
+  });
+});
+
+describe("ChainAssetPriorityPolicy — per-asset overrides", () => {
+  const policy = new ChainAssetPriorityPolicy({
+    "8453": {
+      default: ["aerodrome", "uniswap"],
+      "by-asset": {
+        USDC: ["uniswap", "aerodrome"],
+      },
+    },
+  });
+
+  it("uses asset-specific order when asset matches", () => {
+    const r = policy
+      .rank([uniswap, aerodrome], { chainId: 8453, asset: "USDC" })
+      .map((p) => p.name);
+    expect(r).toEqual(["uniswap", "aerodrome"]);
+  });
+
+  it("falls back to default when asset not in overrides", () => {
+    const r = policy
+      .rank([uniswap, aerodrome], { chainId: 8453, asset: "DAI" })
+      .map((p) => p.name);
+    expect(r).toEqual(["aerodrome", "uniswap"]);
+  });
+
+  it("falls back to default when asset not provided", () => {
+    const r = policy
+      .rank([uniswap, aerodrome], { chainId: 8453 })
+      .map((p) => p.name);
+    expect(r).toEqual(["aerodrome", "uniswap"]);
+  });
+});
+
+describe("ChainAssetPriorityPolicy — guards", () => {
+  it("throws on missing config", () => {
+    // @ts-expect-error — intentional
+    expect(() => new ChainAssetPriorityPolicy(null)).toThrowError(CapabilityError);
+  });
+});
+
+describe("fallbackInvoke — happy path", () => {
+  it("returns first supporting provider's result", async () => {
+    const outcome = await fallbackInvoke({
+      ranked: [aerodrome, uniswap],
+      supportsRoute: async (p) => p.name === "aerodrome",
+      invoke: async (p) => `swap via ${p.name}`,
+      capability: "swap",
+    });
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result).toBe("swap via aerodrome");
+      expect(outcome.provider).toBe(aerodrome);
+      expect(outcome.attempts).toEqual([]);
+    }
+  });
+});
+
+describe("fallbackInvoke — supportsRoute skips", () => {
+  it("records skip reason and tries next", async () => {
+    const outcome = await fallbackInvoke({
+      ranked: [aerodrome, uniswap],
+      supportsRoute: async (p) => p.name !== "aerodrome",
+      invoke: async (p) => `swap via ${p.name}`,
+      capability: "swap",
+    });
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result).toBe("swap via uniswap");
+      expect(outcome.attempts).toEqual([{ provider: "aerodrome", reason: "route unsupported" }]);
+    }
+  });
+
+  it("supportsRoute throwing is treated as 'route unsupported by this provider'", async () => {
+    const outcome = await fallbackInvoke({
+      ranked: [aerodrome, uniswap],
+      supportsRoute: async (p) => {
+        if (p.name === "aerodrome") throw new Error("rpc down");
+        return true;
+      },
+      invoke: async () => "ok",
+      capability: "swap",
+    });
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.attempts[0]?.reason).toMatch(/supportsRoute threw/);
+    }
+  });
+});
+
+describe("fallbackInvoke — invoke errors", () => {
+  it("falls back on generic error and keeps trying", async () => {
+    const invoke = vi.fn(async (p: SwapP) => {
+      if (p.name === "aerodrome") throw new Error("liquidity gone");
+      return `ok ${p.name}`;
+    });
+    const outcome = await fallbackInvoke({
+      ranked: [aerodrome, uniswap],
+      supportsRoute: async () => true,
+      invoke,
+      capability: "swap",
+    });
+    expect(outcome.ok).toBe(true);
+    if (outcome.ok) {
+      expect(outcome.result).toBe("ok uniswap");
+      expect(outcome.attempts[0]).toEqual({ provider: "aerodrome", reason: "liquidity gone" });
+    }
+    expect(invoke).toHaveBeenCalledTimes(2);
+  });
+
+  it("rethrows VALIDATION errors immediately (no fallback)", async () => {
+    const err = CapabilityError.validation({
+      capability: "swap",
+      message: "amount must be > 0",
+    });
+    const invoke = vi.fn(async () => {
+      throw err;
+    });
+    await expect(
+      fallbackInvoke({
+        ranked: [aerodrome, uniswap],
+        supportsRoute: async () => true,
+        invoke,
+        capability: "swap",
+      })
+    ).rejects.toThrowError(err);
+    expect(invoke).toHaveBeenCalledTimes(1);
+  });
+
+  it("rethrows UNSUPPORTED_ROUTE immediately", async () => {
+    const err = CapabilityError.unsupportedRoute({
+      capability: "swap",
+      chainId: 1,
+      attempted: ["aerodrome"],
+    });
+    await expect(
+      fallbackInvoke({
+        ranked: [aerodrome, uniswap],
+        supportsRoute: async () => true,
+        invoke: async () => {
+          throw err;
+        },
+        capability: "swap",
+      })
+    ).rejects.toBe(err);
+  });
+
+  it("custom shouldFallback overrides default", async () => {
+    const err = CapabilityError.validation({
+      capability: "swap",
+      message: "x",
+    });
+    const outcome = await fallbackInvoke({
+      ranked: [aerodrome, uniswap],
+      supportsRoute: async () => true,
+      invoke: async (p) => {
+        if (p.name === "aerodrome") throw err;
+        return "ok uniswap";
+      },
+      shouldFallback: () => "fallback", // override: never rethrow
+      capability: "swap",
+    });
+    expect(outcome.ok).toBe(true);
+  });
+});
+
+describe("fallbackInvoke — total failure", () => {
+  it("returns failure with allProvidersFailed error", async () => {
+    const outcome = await fallbackInvoke({
+      ranked: [aerodrome, uniswap],
+      supportsRoute: async () => false,
+      invoke: async () => "never",
+      capability: "swap",
+    });
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.error).toBeInstanceOf(CapabilityError);
+      expect(outcome.error.code).toBe("CAPABILITY_SWAP_ALL_PROVIDERS_FAILED");
+      expect(outcome.error.category).toBe(ErrorCategory.UNAVAILABLE);
+      expect(outcome.attempts).toHaveLength(2);
+    }
+  });
+
+  it("returns failure when ranked is empty", async () => {
+    const outcome = await fallbackInvoke({
+      ranked: [],
+      supportsRoute: async () => true,
+      invoke: async () => "never",
+      capability: "swap",
+    });
+    expect(outcome.ok).toBe(false);
+    if (!outcome.ok) {
+      expect(outcome.attempts).toEqual([]);
+      expect(outcome.error.details).toMatchObject({ capability: "swap", attempts: [] });
+    }
+  });
+});

--- a/shared/capability/__tests__/provider-limitations.test.ts
+++ b/shared/capability/__tests__/provider-limitations.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  applyLimitations,
+  compareDecimalStrings,
+  type ProviderLimitations,
+} from "../provider-limitations";
+import { CapabilityError, ErrorCategory } from "../errors";
+
+describe("compareDecimalStrings", () => {
+  it("returns 0 for equal", () => {
+    expect(compareDecimalStrings("100", "100")).toBe(0);
+    expect(compareDecimalStrings("0", "0")).toBe(0);
+    expect(compareDecimalStrings("00100", "100")).toBe(0);
+  });
+
+  it("returns -1 / 1 for less / greater (different lengths)", () => {
+    expect(compareDecimalStrings("99", "100")).toBe(-1);
+    expect(compareDecimalStrings("1000", "999")).toBe(1);
+  });
+
+  it("returns -1 / 1 for same-length comparison", () => {
+    expect(compareDecimalStrings("123", "124")).toBe(-1);
+    expect(compareDecimalStrings("999", "123")).toBe(1);
+  });
+
+  it("trims whitespace and leading zeros", () => {
+    expect(compareDecimalStrings("  100  ", "100")).toBe(0);
+    expect(compareDecimalStrings("0000050", "50")).toBe(0);
+  });
+
+  it("throws on invalid input", () => {
+    expect(() => compareDecimalStrings("12.5", "1")).toThrow();
+    expect(() => compareDecimalStrings("-1", "0")).toThrow();
+    expect(() => compareDecimalStrings("abc", "1")).toThrow();
+  });
+
+  it("handles huge values (wei-scale)", () => {
+    const max = "115792089237316195423570985008687907853269984665640564039457584007913129639935"; // uint256 max
+    expect(compareDecimalStrings(max, "1")).toBe(1);
+    expect(compareDecimalStrings(max, max)).toBe(0);
+  });
+});
+
+describe("applyLimitations — blockedTokens", () => {
+  it("rejects when asset is in blocked list", () => {
+    const r = applyLimitations({
+      capability: "swap",
+      provider: "uniswap",
+      limitations: { blockedTokens: ["USDT"] },
+      asset: "USDT",
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error).toBeInstanceOf(CapabilityError);
+      expect(r.error.category).toBe(ErrorCategory.VALIDATION);
+      expect(r.error.details).toMatchObject({
+        errors: [{ field: "asset", reason: "blocked", value: "USDT" }],
+      });
+    }
+  });
+
+  it("allows when asset not in blocked list", () => {
+    const r = applyLimitations({
+      capability: "swap",
+      provider: "uniswap",
+      limitations: { blockedTokens: ["USDT"] },
+      asset: "USDC",
+    });
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe("applyLimitations — blockedChains", () => {
+  it("rejects when chain is blocked", () => {
+    const r = applyLimitations({
+      capability: "swap",
+      provider: "aerodrome",
+      limitations: { blockedChains: [1] },
+      chainId: 1,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error.category).toBe(ErrorCategory.VALIDATION);
+    }
+  });
+});
+
+describe("applyLimitations — amount range", () => {
+  const lim: ProviderLimitations = {
+    minAmountByAsset: { USDC: "1000000" }, // 1 USDC (6 decimals)
+    maxAmountByAsset: { USDC: "100000000000" }, // 100,000 USDC
+  };
+
+  it("rejects below min", () => {
+    const r = applyLimitations({
+      capability: "swap",
+      provider: "uniswap",
+      limitations: lim,
+      asset: "USDC",
+      amount: "999999",
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error.details).toMatchObject({
+        errors: [{ field: "amount", reason: "below-min", value: "999999", min: "1000000" }],
+      });
+    }
+  });
+
+  it("rejects above max", () => {
+    const r = applyLimitations({
+      capability: "swap",
+      provider: "uniswap",
+      limitations: lim,
+      asset: "USDC",
+      amount: "100000000001",
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error.details).toMatchObject({
+        errors: [{ field: "amount", reason: "above-max" }],
+      });
+    }
+  });
+
+  it("accepts within range (inclusive at min, inclusive at max)", () => {
+    expect(
+      applyLimitations({
+        capability: "swap",
+        provider: "uniswap",
+        limitations: lim,
+        asset: "USDC",
+        amount: "1000000",
+      }).ok
+    ).toBe(true);
+    expect(
+      applyLimitations({
+        capability: "swap",
+        provider: "uniswap",
+        limitations: lim,
+        asset: "USDC",
+        amount: "100000000000",
+      }).ok
+    ).toBe(true);
+  });
+
+  it("does not check amount when asset key missing in maps", () => {
+    const r = applyLimitations({
+      capability: "swap",
+      provider: "uniswap",
+      limitations: lim,
+      asset: "DAI", // no entry
+      amount: "0",
+    });
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe("applyLimitations — dailyVolumeLimit", () => {
+  it("rate-limits when today's volume meets or exceeds the cap", () => {
+    const r = applyLimitations({
+      capability: "swap",
+      provider: "uniswap",
+      limitations: { dailyVolumeLimitUsd: 10000 },
+      todayVolumeUsd: 10000,
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error.category).toBe(ErrorCategory.RATE_LIMITED);
+      expect(r.error.code).toBe("CAPABILITY_SWAP_RATE_LIMITED");
+    }
+  });
+
+  it("allows below the cap", () => {
+    expect(
+      applyLimitations({
+        capability: "swap",
+        provider: "uniswap",
+        limitations: { dailyVolumeLimitUsd: 10000 },
+        todayVolumeUsd: 9999.99,
+      }).ok
+    ).toBe(true);
+  });
+});
+
+describe("applyLimitations — composition", () => {
+  it("returns the first failing rule (asset blocked beats amount check)", () => {
+    const r = applyLimitations({
+      capability: "swap",
+      provider: "uniswap",
+      limitations: {
+        blockedTokens: ["USDT"],
+        minAmountByAsset: { USDT: "1000000" },
+      },
+      asset: "USDT",
+      amount: "999999", // would also fail min, but blockedTokens fires first
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.error.message).toMatch(/does not support asset "USDT"/);
+    }
+  });
+
+  it("passes when no limitation fires", () => {
+    const r = applyLimitations({
+      capability: "swap",
+      provider: "uniswap",
+      limitations: {},
+    });
+    expect(r.ok).toBe(true);
+  });
+});

--- a/shared/capability/__tests__/registry.conformance.self.test.ts
+++ b/shared/capability/__tests__/registry.conformance.self.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Self-test: run the conformance helper against an in-package fake registry, ensuring the helper
+ * itself behaves before any consuming capability adopts it.
+ */
+
+import { ProviderRegistry } from "../registry";
+import {
+  describeRegistryConformance,
+  type ConformanceProvider,
+  type ConformanceSetup,
+} from "./registry.conformance";
+
+interface FakeProvider extends ConformanceProvider {}
+
+function fake(input: {
+  name: string;
+  chainIds: number[];
+  enabled?: boolean;
+}): FakeProvider {
+  return {
+    name: input.name,
+    metadata: {
+      name: input.name,
+      capability: "swap",
+      supportedChains: input.chainIds,
+      version: "1.0.0",
+      ...(input.enabled !== undefined && { enabled: input.enabled }),
+    },
+    supportsRoute: async ({ chainId }) => input.chainIds.includes(chainId),
+    run: async () => `${input.name}-ran`,
+  };
+}
+
+function setup(): ConformanceSetup<FakeProvider> {
+  return {
+    registry: new ProviderRegistry<FakeProvider>(),
+    providers: {
+      chainA: fake({ name: "fake-a", chainIds: [1] }),
+      chainB: fake({ name: "fake-b", chainIds: [8453] }),
+      stub: fake({ name: "fake-stub", chainIds: [1], enabled: false }),
+    },
+    chainAId: 1,
+    chainBId: 8453,
+  };
+}
+
+describeRegistryConformance("swap", () => setup());

--- a/shared/capability/__tests__/registry.conformance.ts
+++ b/shared/capability/__tests__/registry.conformance.ts
@@ -1,0 +1,250 @@
+/**
+ * registry.conformance — reusable test helper.
+ *
+ * Every capability service runs this suite against its own registry to guarantee that the
+ * generic registry contract holds end-to-end (registration, lookup, filtering, health, policy
+ * integration). The helper is NOT itself a test file — it's a function that mounts a `describe`
+ * block when called.
+ *
+ *     // in <service>/src/__tests__/<cap>.conformance.test.ts
+ *     import { describeRegistryConformance } from '@panorama/capability/__tests__/registry.conformance';
+ *     import { setupSwapRegistry } from '../some-fixture';
+ *
+ *     describeRegistryConformance('swap', () => setupSwapRegistry());
+ *
+ * The factory returns the registry + a small set of providers + a helper to register them,
+ * letting each capability run the same suite against its own concrete adapter instances.
+ *
+ * Card #210 (SPRINT_HUGO.md).
+ */
+
+import { describe, it, expect } from "vitest";
+
+import { CapabilityError } from "../errors";
+import type { CapabilitySlug, ICapabilityProvider } from "../provider.types";
+import { ChainAssetPriorityPolicy, fallbackInvoke } from "../policy";
+import type { ProviderRegistry } from "../registry";
+
+// -------------------------------------------------------------------------------------------------
+// Factory contract — what each capability must supply
+// -------------------------------------------------------------------------------------------------
+
+export interface ConformanceProvider extends ICapabilityProvider {
+  /** Reports whether this provider supports the route — used by the fallback iteration test. */
+  supportsRoute?: (input: { chainId: number }) => Promise<boolean>;
+  /** Performs the canonical action of the capability. The test only needs a stable return. */
+  run?: () => Promise<string>;
+}
+
+export interface ConformanceSetup<TProvider extends ConformanceProvider> {
+  registry: ProviderRegistry<TProvider>;
+  /** Three providers ready to register: one supports chain A, one supports chain B, one is a stub. */
+  providers: {
+    chainA: TProvider;
+    chainB: TProvider;
+    stub: TProvider;
+  };
+  /** Chain id A: registered chain that providers.chainA supports. */
+  chainAId: number;
+  /** Chain id B: registered chain that providers.chainB supports. */
+  chainBId: number;
+}
+
+export type ConformanceFactory<TProvider extends ConformanceProvider> = () =>
+  | ConformanceSetup<TProvider>
+  | Promise<ConformanceSetup<TProvider>>;
+
+// -------------------------------------------------------------------------------------------------
+// The suite
+// -------------------------------------------------------------------------------------------------
+
+/**
+ * Mount the conformance suite. Call from inside a capability's test file.
+ *
+ * @param capability — slug for naming + factory access (e.g. 'swap', 'staking')
+ * @param factory — produces a fresh setup per test (registry must be empty before .register calls)
+ */
+export function describeRegistryConformance<TProvider extends ConformanceProvider>(
+  capability: CapabilitySlug,
+  factory: ConformanceFactory<TProvider>
+): void {
+  describe(`registry conformance — ${capability}`, () => {
+    it("registers all three providers without throwing", async () => {
+      const setup = await factory();
+      setup.registry.register(setup.providers.chainA);
+      setup.registry.register(setup.providers.chainB);
+      setup.registry.register(setup.providers.stub);
+      expect(setup.registry.size()).toBe(3);
+    });
+
+    it("getByName returns the right provider", async () => {
+      const setup = await factory();
+      setup.registry.register(setup.providers.chainA);
+      const found = setup.registry.getByName(setup.providers.chainA.name);
+      expect(found?.name).toBe(setup.providers.chainA.name);
+    });
+
+    it("rejects duplicate names with CapabilityError", async () => {
+      const setup = await factory();
+      setup.registry.register(setup.providers.chainA);
+      expect(() => setup.registry.register(setup.providers.chainA)).toThrowError(CapabilityError);
+    });
+
+    it("listByChain narrows to chain-supporting providers", async () => {
+      const setup = await factory();
+      setup.registry.register(setup.providers.chainA);
+      setup.registry.register(setup.providers.chainB);
+      const a = setup.registry.listByChain(setup.chainAId).map((p) => p.name);
+      const b = setup.registry.listByChain(setup.chainBId).map((p) => p.name);
+      expect(a).toContain(setup.providers.chainA.name);
+      expect(a).not.toContain(setup.providers.chainB.name);
+      expect(b).toContain(setup.providers.chainB.name);
+      expect(b).not.toContain(setup.providers.chainA.name);
+    });
+
+    it("listByChain excludes disabled stubs by default", async () => {
+      const setup = await factory();
+      setup.registry.register(setup.providers.chainA);
+      setup.registry.register(setup.providers.stub);
+      const stubChain = (setup.providers.stub.metadata.supportedChains[0] as number) ?? setup.chainAId;
+      const names = setup.registry.listByChain(stubChain).map((p) => p.name);
+      expect(names).not.toContain(setup.providers.stub.name);
+    });
+
+    it("listByChain with includeDisabled returns the stub", async () => {
+      const setup = await factory();
+      setup.registry.register(setup.providers.stub);
+      const stubChain = (setup.providers.stub.metadata.supportedChains[0] as number) ?? setup.chainAId;
+      const names = setup.registry
+        .listByChain(stubChain, { includeDisabled: true })
+        .map((p) => p.name);
+      expect(names).toContain(setup.providers.stub.name);
+    });
+
+    it("health oracle filters out unhealthy", async () => {
+      const setup = await factory();
+      setup.registry.register(setup.providers.chainA);
+      setup.registry.register(setup.providers.chainB);
+      // Mark chainA unhealthy
+      const aName = setup.providers.chainA.name;
+      setup.registry.attachHealthOracle({ isHealthy: (n) => n !== aName });
+      const visible = setup.registry.listByChain(setup.chainAId).map((p) => p.name);
+      expect(visible).not.toContain(aName);
+      // Detach → all healthy again
+      setup.registry.attachHealthOracle(undefined);
+      expect(setup.registry.listByChain(setup.chainAId).map((p) => p.name)).toContain(aName);
+    });
+
+    it("metadataSnapshot returns one entry per provider", async () => {
+      const setup = await factory();
+      setup.registry.register(setup.providers.chainA);
+      setup.registry.register(setup.providers.chainB);
+      expect(setup.registry.metadataSnapshot()).toHaveLength(2);
+    });
+
+    it("policy ranks providers per chain id", async () => {
+      const setup = await factory();
+      setup.registry.register(setup.providers.chainA);
+      setup.registry.register(setup.providers.chainB);
+      const policy = new ChainAssetPriorityPolicy({
+        [setup.chainAId.toString()]: [setup.providers.chainA.name],
+        [setup.chainBId.toString()]: [setup.providers.chainB.name],
+      });
+      const aRanked = policy
+        .rank(setup.registry.listAll(), { chainId: setup.chainAId })
+        .map((p) => p.name);
+      expect(aRanked[0]).toBe(setup.providers.chainA.name);
+    });
+
+    it("fallbackInvoke succeeds on first supporting provider", async () => {
+      const setup = await factory();
+      // Use only providers that have supportsRoute + run (skip stub which throws)
+      const A = withDefaults(setup.providers.chainA);
+      const B = withDefaults(setup.providers.chainB);
+      setup.registry.register(setup.providers.chainA);
+      setup.registry.register(setup.providers.chainB);
+
+      const outcome = await fallbackInvoke({
+        ranked: [A, B],
+        supportsRoute: (p) => p.supportsRoute!({ chainId: setup.chainAId }),
+        invoke: (p) => p.run!(),
+        capability,
+      });
+      expect(outcome.ok).toBe(true);
+      if (outcome.ok) {
+        expect(outcome.provider.name).toBe(A.name);
+      }
+    });
+
+    it("fallbackInvoke falls back when first does not support", async () => {
+      const setup = await factory();
+      const A = withDefaults(setup.providers.chainA);
+      const B = withDefaults(setup.providers.chainB);
+      setup.registry.register(setup.providers.chainA);
+      setup.registry.register(setup.providers.chainB);
+
+      const outcome = await fallbackInvoke({
+        ranked: [A, B],
+        supportsRoute: (p) => p.supportsRoute!({ chainId: setup.chainBId }),
+        invoke: (p) => p.run!(),
+        capability,
+      });
+      expect(outcome.ok).toBe(true);
+      if (outcome.ok) {
+        expect(outcome.provider.name).toBe(B.name);
+        expect(outcome.attempts[0]?.reason).toBe("route unsupported");
+      }
+    });
+
+    it("fallbackInvoke returns allProvidersFailed when none support", async () => {
+      const setup = await factory();
+      const A = withDefaults(setup.providers.chainA);
+      const B = withDefaults(setup.providers.chainB);
+
+      const outcome = await fallbackInvoke({
+        ranked: [A, B],
+        supportsRoute: async () => false,
+        invoke: async () => "never",
+        capability,
+      });
+      expect(outcome.ok).toBe(false);
+      if (!outcome.ok) {
+        expect(outcome.error).toBeInstanceOf(CapabilityError);
+      }
+    });
+
+    it("unregister + re-register flow works", async () => {
+      const setup = await factory();
+      setup.registry.register(setup.providers.chainA);
+      expect(setup.registry.unregister(setup.providers.chainA.name)).toBe(true);
+      expect(setup.registry.size()).toBe(0);
+      setup.registry.register(setup.providers.chainA);
+      expect(setup.registry.getByName(setup.providers.chainA.name)).toBeDefined();
+    });
+
+    it("clear empties the registry", async () => {
+      const setup = await factory();
+      setup.registry.register(setup.providers.chainA);
+      setup.registry.register(setup.providers.chainB);
+      setup.registry.clear();
+      expect(setup.registry.size()).toBe(0);
+    });
+
+    it("metadata.capability matches the suite slug", async () => {
+      const setup = await factory();
+      for (const p of [setup.providers.chainA, setup.providers.chainB]) {
+        expect(p.metadata.capability).toBe(capability);
+      }
+    });
+  });
+}
+
+// Provide default supportsRoute / run so the helper works even if the caller's providers omit them.
+function withDefaults<TProvider extends ConformanceProvider>(p: TProvider): TProvider {
+  const chains = p.metadata.supportedChains;
+  const supportsRoute =
+    p.supportsRoute ??
+    (async (input: { chainId: number }) => chains.includes(input.chainId));
+  const run = p.run ?? (async () => `${p.name}-ok`);
+  return { ...p, supportsRoute, run } as TProvider;
+}

--- a/shared/capability/__tests__/registry.loader.test.ts
+++ b/shared/capability/__tests__/registry.loader.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi } from "vitest";
+import { writeFileSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { ProviderRegistry } from "../registry";
+import {
+  loadProvidersFromConfig,
+  type ProviderConfigFile,
+  type ProviderFactory,
+} from "../registry.loader";
+import type { ICapabilityProvider } from "../provider.types";
+import { CapabilityError } from "../errors";
+
+interface SwapProvider extends ICapabilityProvider {}
+
+function factoryForFixed(): ProviderFactory<SwapProvider> {
+  return (entry) =>
+    ({
+      name: entry.name,
+      metadata: {
+        name: entry.name,
+        capability: entry.capability as "swap",
+        supportedChains: entry.supportedChains,
+        version: entry.version,
+        ...(entry.features !== undefined && { features: entry.features }),
+        ...(entry.enabled !== undefined && { enabled: entry.enabled }),
+      },
+    }) satisfies SwapProvider;
+}
+
+function validConfig(): ProviderConfigFile {
+  return {
+    providers: [
+      {
+        name: "uniswap",
+        capability: "swap",
+        supportedChains: [1, 8453],
+        version: "1.0.0",
+        enabled: true,
+      },
+      {
+        name: "aerodrome",
+        capability: "swap",
+        supportedChains: [8453],
+        version: "1.0.0",
+        enabled: true,
+      },
+    ],
+  };
+}
+
+describe("loadProvidersFromConfig — config arg", () => {
+  it("registers all enabled providers from in-memory config", () => {
+    const r = new ProviderRegistry<SwapProvider>();
+    const result = loadProvidersFromConfig(r, {
+      config: validConfig(),
+      factory: factoryForFixed(),
+    });
+    expect(result.registered.sort()).toEqual(["aerodrome", "uniswap"]);
+    expect(result.skipped).toEqual([]);
+    expect(result.errors).toEqual([]);
+    expect(r.size()).toBe(2);
+  });
+
+  it("skips disabled providers by default", () => {
+    const r = new ProviderRegistry<SwapProvider>();
+    const config: ProviderConfigFile = {
+      providers: [
+        { name: "uniswap", capability: "swap", supportedChains: [1], version: "1.0.0", enabled: true },
+        { name: "thirdweb", capability: "swap", supportedChains: [1], version: "1.0.0", enabled: false },
+      ],
+    };
+    const result = loadProvidersFromConfig(r, { config, factory: factoryForFixed() });
+    expect(result.registered).toEqual(["uniswap"]);
+    expect(result.skipped).toEqual([{ name: "thirdweb", reason: "disabled in config" }]);
+    expect(r.getByName("thirdweb")).toBeUndefined();
+  });
+
+  it("with skipDisabled: false, sends disabled to factory + registry", () => {
+    const r = new ProviderRegistry<SwapProvider>();
+    const config: ProviderConfigFile = {
+      providers: [
+        { name: "uniswap", capability: "swap", supportedChains: [1], version: "1.0.0", enabled: true },
+        { name: "thirdweb", capability: "swap", supportedChains: [1], version: "1.0.0", enabled: false },
+      ],
+    };
+    const result = loadProvidersFromConfig(r, {
+      config,
+      factory: factoryForFixed(),
+      skipDisabled: false,
+    });
+    expect(result.registered.sort()).toEqual(["thirdweb", "uniswap"]);
+    expect(r.size()).toBe(2);
+    expect(r.listAll().map((p) => p.name)).toEqual(["uniswap"]); // listAll defaults to enabled-only
+    expect(r.listAll({ includeDisabled: true }).map((p) => p.name).sort()).toEqual([
+      "thirdweb",
+      "uniswap",
+    ]);
+  });
+
+  it("skips providers when factory returns null", () => {
+    const r = new ProviderRegistry<SwapProvider>();
+    const factory: ProviderFactory<SwapProvider> = (entry) =>
+      entry.name === "aerodrome" ? null : factoryForFixed()(entry);
+    const result = loadProvidersFromConfig(r, { config: validConfig(), factory });
+    expect(result.registered).toEqual(["uniswap"]);
+    expect(result.skipped).toEqual([{ name: "aerodrome", reason: "factory returned null" }]);
+  });
+});
+
+describe("loadProvidersFromConfig — validation failures", () => {
+  it("aborts when ANY entry has invalid metadata, lists every error", () => {
+    const r = new ProviderRegistry<SwapProvider>();
+    const config: ProviderConfigFile = {
+      providers: [
+        { name: "BadCase", capability: "swap", supportedChains: [1], version: "1.0.0" },
+        { name: "unknown-cap", capability: "derivatives", supportedChains: [1], version: "1.0.0" },
+      ],
+    };
+    expect(() =>
+      loadProvidersFromConfig(r, { config, factory: factoryForFixed() })
+    ).toThrowError(CapabilityError);
+
+    try {
+      loadProvidersFromConfig(r, { config, factory: factoryForFixed() });
+    } catch (e) {
+      const err = e as CapabilityError;
+      expect(err.code).toBe("CAPABILITY_REGISTRY_LOAD_FAILED");
+      expect(err.details).toMatchObject({
+        validationErrors: expect.arrayContaining([
+          expect.objectContaining({ name: "BadCase" }),
+          expect.objectContaining({ name: "unknown-cap" }),
+        ]),
+      });
+    }
+    expect(r.size()).toBe(0); // no partial register
+  });
+
+  it("aborts when factory throws (treated as internal error)", () => {
+    const r = new ProviderRegistry<SwapProvider>();
+    const factory: ProviderFactory<SwapProvider> = vi.fn(() => {
+      throw new Error("missing env var BENQI_RPC_URL");
+    });
+    expect(() =>
+      loadProvidersFromConfig(r, { config: validConfig(), factory })
+    ).toThrowError(/Factory threw for provider/);
+    expect(factory).toHaveBeenCalledOnce(); // aborts on first failure
+    expect(r.size()).toBe(0);
+  });
+
+  it("rejects config arg without providers array (bad shape)", () => {
+    const r = new ProviderRegistry<SwapProvider>();
+    expect(() =>
+      loadProvidersFromConfig(r, {
+        // @ts-expect-error — intentionally bad
+        config: { wrong: true },
+        factory: factoryForFixed(),
+      })
+    ).toThrow();
+  });
+
+  it("requires configPath OR config", () => {
+    const r = new ProviderRegistry<SwapProvider>();
+    expect(() =>
+      loadProvidersFromConfig(r, {
+        factory: factoryForFixed(),
+      })
+    ).toThrowError(/Either configPath or config/);
+  });
+});
+
+describe("loadProvidersFromConfig — configPath (filesystem)", () => {
+  it("reads + parses + loads from disk", () => {
+    const dir = mkdtempSync(join(tmpdir(), "capability-loader-"));
+    const path = join(dir, "providers.test.json");
+    writeFileSync(path, JSON.stringify(validConfig()), "utf-8");
+
+    const r = new ProviderRegistry<SwapProvider>();
+    const result = loadProvidersFromConfig(r, {
+      configPath: path,
+      factory: factoryForFixed(),
+    });
+    expect(result.registered.sort()).toEqual(["aerodrome", "uniswap"]);
+  });
+
+  it("errors with a structured CapabilityError when file is missing", () => {
+    const r = new ProviderRegistry<SwapProvider>();
+    expect(() =>
+      loadProvidersFromConfig(r, {
+        configPath: "/nonexistent/path/providers.json",
+        factory: factoryForFixed(),
+      })
+    ).toThrowError(/Cannot read provider config/);
+  });
+
+  it("errors when JSON is malformed", () => {
+    const dir = mkdtempSync(join(tmpdir(), "capability-loader-"));
+    const path = join(dir, "bad.json");
+    writeFileSync(path, "{not json", "utf-8");
+
+    const r = new ProviderRegistry<SwapProvider>();
+    expect(() =>
+      loadProvidersFromConfig(r, {
+        configPath: path,
+        factory: factoryForFixed(),
+      })
+    ).toThrowError(/not valid JSON/);
+  });
+});

--- a/shared/capability/__tests__/registry.test.ts
+++ b/shared/capability/__tests__/registry.test.ts
@@ -1,0 +1,280 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { ProviderRegistry } from "../registry";
+import { CapabilityError } from "../errors";
+import type { ICapabilityProvider } from "../provider.types";
+import type { HealthOracle } from "../registry.types";
+
+interface SwapProvider extends ICapabilityProvider {
+  swap(): string;
+}
+
+function provider(input: {
+  name: string;
+  capability?: "swap" | "lending" | "staking";
+  supportedChains?: number[];
+  enabled?: boolean;
+}): SwapProvider {
+  return {
+    name: input.name,
+    metadata: {
+      name: input.name,
+      capability: input.capability ?? "swap",
+      supportedChains: input.supportedChains ?? [1],
+      version: "1.0.0",
+      ...(input.enabled !== undefined && { enabled: input.enabled }),
+    },
+    swap: () => input.name,
+  };
+}
+
+describe("ProviderRegistry — register", () => {
+  it("registers a provider and lists it back", () => {
+    const r = new ProviderRegistry<SwapProvider>();
+    r.register(provider({ name: "uniswap" }));
+    expect(r.size()).toBe(1);
+    expect(r.getByName("uniswap")?.swap()).toBe("uniswap");
+  });
+
+  it("throws CapabilityError on duplicate name", () => {
+    const r = new ProviderRegistry<SwapProvider>();
+    r.register(provider({ name: "uniswap" }));
+    expect(() => r.register(provider({ name: "uniswap" }))).toThrowError(CapabilityError);
+    try {
+      r.register(provider({ name: "uniswap" }));
+    } catch (e) {
+      const err = e as CapabilityError;
+      expect(err.code).toBe("CAPABILITY_REGISTRY_DUPLICATE");
+      expect(err.httpStatus).toBe(400);
+    }
+  });
+
+  it("throws on invalid metadata (rejected by validateProviderMetadata)", () => {
+    const r = new ProviderRegistry<SwapProvider>();
+    const bad: SwapProvider = {
+      name: "BadCase",
+      metadata: {
+        name: "BadCase", // uppercase, will fail
+        capability: "swap",
+        supportedChains: [1],
+        version: "1.0.0",
+      },
+      swap: () => "x",
+    };
+    expect(() => r.register(bad)).toThrowError(CapabilityError);
+  });
+
+  it("throws when provider.name and metadata.name disagree", () => {
+    const r = new ProviderRegistry<SwapProvider>();
+    const mismatched: SwapProvider = {
+      name: "uniswap",
+      metadata: {
+        name: "different-name",
+        capability: "swap",
+        supportedChains: [1],
+        version: "1.0.0",
+      },
+      swap: () => "x",
+    };
+    expect(() => r.register(mismatched)).toThrowError(/name/);
+  });
+});
+
+describe("ProviderRegistry — unregister", () => {
+  it("removes an existing provider and returns true", () => {
+    const r = new ProviderRegistry<SwapProvider>();
+    r.register(provider({ name: "uniswap" }));
+    expect(r.unregister("uniswap")).toBe(true);
+    expect(r.size()).toBe(0);
+  });
+
+  it("returns false for missing provider", () => {
+    const r = new ProviderRegistry<SwapProvider>();
+    expect(r.unregister("ghost")).toBe(false);
+  });
+});
+
+describe("ProviderRegistry — listAll filters", () => {
+  function setup() {
+    const r = new ProviderRegistry<SwapProvider>();
+    r.register(provider({ name: "uniswap", capability: "swap", supportedChains: [1, 8453] }));
+    r.register(provider({ name: "aerodrome", capability: "swap", supportedChains: [8453] }));
+    r.register(
+      provider({ name: "benqi", capability: "lending", supportedChains: [43114] }) as SwapProvider
+    );
+    r.register(
+      provider({
+        name: "base-staking-stub",
+        capability: "staking",
+        supportedChains: [8453],
+        enabled: false,
+      }) as SwapProvider
+    );
+    return r;
+  }
+
+  it("no filter — returns all non-disabled providers (3, stub excluded)", () => {
+    const r = setup();
+    expect(r.listAll().map((p) => p.name).sort()).toEqual(["aerodrome", "benqi", "uniswap"]);
+  });
+
+  it("includeDisabled: true also returns stubs", () => {
+    const r = setup();
+    expect(r.listAll({ includeDisabled: true }).length).toBe(4);
+  });
+
+  it("capability filter narrows", () => {
+    const r = setup();
+    expect(r.listAll({ capability: "swap" }).map((p) => p.name).sort()).toEqual([
+      "aerodrome",
+      "uniswap",
+    ]);
+    expect(r.listAll({ capability: "lending" }).map((p) => p.name)).toEqual(["benqi"]);
+  });
+
+  it("healthy filter consults the oracle", () => {
+    const r = setup();
+    r.attachHealthOracle({ isHealthy: (n) => n !== "aerodrome" });
+    expect(r.listAll({ healthy: true }).map((p) => p.name).sort()).toEqual([
+      "benqi",
+      "uniswap",
+    ]);
+    expect(r.listAll({ healthy: false }).map((p) => p.name)).toEqual(["aerodrome"]);
+  });
+});
+
+describe("ProviderRegistry — listByChain", () => {
+  function setup() {
+    const r = new ProviderRegistry<SwapProvider>();
+    r.register(provider({ name: "uniswap", capability: "swap", supportedChains: [1, 8453] }));
+    r.register(provider({ name: "aerodrome", capability: "swap", supportedChains: [8453] }));
+    r.register(
+      provider({ name: "lido", capability: "staking", supportedChains: [1] }) as SwapProvider
+    );
+    return r;
+  }
+
+  it("returns providers that include the chain id", () => {
+    const r = setup();
+    expect(r.listByChain(8453).map((p) => p.name).sort()).toEqual([
+      "aerodrome",
+      "uniswap",
+    ]);
+    expect(r.listByChain(1).map((p) => p.name).sort()).toEqual(["lido", "uniswap"]);
+  });
+
+  it("returns empty for unsupported chain", () => {
+    const r = setup();
+    expect(r.listByChain(137)).toEqual([]);
+  });
+
+  it("filters by capability when requested", () => {
+    const r = setup();
+    expect(r.listByChain(1, { capability: "staking" }).map((p) => p.name)).toEqual(["lido"]);
+    expect(r.listByChain(1, { capability: "swap" }).map((p) => p.name)).toEqual(["uniswap"]);
+  });
+
+  it("excludes unhealthy by default", () => {
+    const r = setup();
+    r.attachHealthOracle({ isHealthy: (n) => n !== "aerodrome" });
+    expect(r.listByChain(8453).map((p) => p.name)).toEqual(["uniswap"]);
+  });
+
+  it("explicit healthy: undefined includes unhealthy", () => {
+    const r = setup();
+    r.attachHealthOracle({ isHealthy: (n) => n !== "aerodrome" });
+    expect(r.listByChain(8453, { healthy: undefined }).map((p) => p.name).sort()).toEqual([
+      "aerodrome",
+      "uniswap",
+    ]);
+  });
+
+  it("excludes disabled stubs by default", () => {
+    const r = setup();
+    r.register(
+      provider({
+        name: "base-staking-stub",
+        capability: "staking",
+        supportedChains: [8453],
+        enabled: false,
+      }) as SwapProvider
+    );
+    expect(r.listByChain(8453, { capability: "staking" })).toEqual([]);
+    expect(
+      r.listByChain(8453, { capability: "staking", includeDisabled: true }).map((p) => p.name)
+    ).toEqual(["base-staking-stub"]);
+  });
+});
+
+describe("ProviderRegistry — health oracle attach/detach", () => {
+  it("defaults to all-healthy when no oracle attached", () => {
+    const r = new ProviderRegistry<SwapProvider>();
+    r.register(provider({ name: "uniswap" }));
+    expect(r.listByChain(1).map((p) => p.name)).toEqual(["uniswap"]);
+  });
+
+  it("falls back to all-healthy when detached (oracle = undefined)", () => {
+    const r = new ProviderRegistry<SwapProvider>();
+    r.register(provider({ name: "uniswap" }));
+    const oracle: HealthOracle = { isHealthy: () => false };
+    r.attachHealthOracle(oracle);
+    expect(r.listByChain(1)).toEqual([]);
+    r.attachHealthOracle(undefined);
+    expect(r.listByChain(1).map((p) => p.name)).toEqual(["uniswap"]);
+  });
+});
+
+describe("ProviderRegistry — subscribe", () => {
+  it("notifies listeners on register/unregister", () => {
+    const r = new ProviderRegistry<SwapProvider>();
+    const listener = vi.fn();
+    const unsub = r.subscribe(listener);
+
+    const p = provider({ name: "uniswap" });
+    r.register(p);
+    r.unregister("uniswap");
+
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect(listener).toHaveBeenNthCalledWith(1, { kind: "registered", provider: p });
+    expect(listener).toHaveBeenNthCalledWith(2, { kind: "unregistered", providerName: "uniswap" });
+
+    unsub();
+    r.register(provider({ name: "thirdweb" }));
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it("isolates listener errors — registry keeps emitting to other listeners", () => {
+    const r = new ProviderRegistry<SwapProvider>();
+    const bad = vi.fn(() => {
+      throw new Error("listener boom");
+    });
+    const good = vi.fn();
+    r.subscribe(bad);
+    r.subscribe(good);
+    expect(() => r.register(provider({ name: "uniswap" }))).not.toThrow();
+    expect(bad).toHaveBeenCalled();
+    expect(good).toHaveBeenCalled();
+  });
+});
+
+describe("ProviderRegistry — metadataSnapshot + clear", () => {
+  it("snapshot returns all metadata", () => {
+    const r = new ProviderRegistry<SwapProvider>();
+    r.register(provider({ name: "uniswap" }));
+    r.register(provider({ name: "aerodrome", supportedChains: [8453] }));
+    const snap = r.metadataSnapshot();
+    expect(snap).toHaveLength(2);
+    expect(snap.map((m) => m.name).sort()).toEqual(["aerodrome", "uniswap"]);
+  });
+
+  it("clear empties the registry and emits unregistered for each", () => {
+    const r = new ProviderRegistry<SwapProvider>();
+    r.register(provider({ name: "uniswap" }));
+    r.register(provider({ name: "aerodrome" }));
+    const listener = vi.fn();
+    r.subscribe(listener);
+    r.clear();
+    expect(r.size()).toBe(0);
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+});

--- a/shared/capability/health.ts
+++ b/shared/capability/health.ts
@@ -1,0 +1,297 @@
+/**
+ * ProviderHealthTracker — periodic health probes + a `HealthOracle` for the registry.
+ *
+ * The tracker polls each provider's optional `healthCheck()` every `intervalMs`. After 3
+ * consecutive failures the provider is marked unhealthy; one success flips it back. The registry
+ * (when this tracker is attached as its `HealthOracle`) automatically excludes unhealthy providers
+ * from `listByChain`, so the capability facade keeps serving without 500s.
+ *
+ * Card #209 (SPRINT_HUGO.md).
+ */
+
+import type { ICapabilityProvider, ProviderHealth } from "./provider.types";
+import type { HealthOracle } from "./registry.types";
+
+// -------------------------------------------------------------------------------------------------
+// State per provider
+// -------------------------------------------------------------------------------------------------
+
+interface ProviderState {
+  name: string;
+  healthy: boolean;
+  consecutiveFailures: number;
+  lastProbe?: ProviderHealth;
+  latencySamplesMs: number[]; // bounded window — keep last N for p95
+}
+
+const LATENCY_WINDOW = 50;
+
+export interface ProviderHealthReport {
+  name: string;
+  healthy: boolean;
+  consecutiveFailures: number;
+  latencyP95Ms?: number;
+  lastCheckedAt?: string;
+  lastReason?: string;
+}
+
+export interface ProviderHealthTrackerOptions {
+  /** Probe interval. Default 30 000 (30 s). */
+  intervalMs?: number;
+  /** Failures in a row before a provider is marked unhealthy. Default 3. */
+  unhealthyAfter?: number;
+  /** Per-probe timeout. Default 5 000 ms. */
+  probeTimeoutMs?: number;
+  /** Injectable clock for tests. */
+  now?: () => Date;
+  /** Injectable scheduler for tests. Default uses `setInterval` / `clearInterval`. */
+  scheduler?: HealthScheduler;
+  /** When a probe throws, this is reported as the reason. */
+  onError?: (providerName: string, error: unknown) => void;
+}
+
+/**
+ * Minimal scheduler surface — abstracted so tests can step time deterministically without
+ * fake-timers gymnastics.
+ */
+export interface HealthScheduler {
+  start(cb: () => void, intervalMs: number): HealthSchedulerHandle;
+}
+export interface HealthSchedulerHandle {
+  stop(): void;
+}
+
+const defaultScheduler: HealthScheduler = {
+  start(cb, intervalMs) {
+    const handle = setInterval(cb, intervalMs);
+    // `unref` so the timer doesn't keep Node alive on shutdown.
+    if (typeof (handle as { unref?: () => void }).unref === "function") {
+      (handle as { unref: () => void }).unref();
+    }
+    return {
+      stop() {
+        clearInterval(handle);
+      },
+    };
+  },
+};
+
+// -------------------------------------------------------------------------------------------------
+// The tracker
+// -------------------------------------------------------------------------------------------------
+
+export class ProviderHealthTracker implements HealthOracle {
+  private readonly providers = new Map<string, ICapabilityProvider>();
+  private readonly state = new Map<string, ProviderState>();
+  private handle?: HealthSchedulerHandle;
+  private readonly intervalMs: number;
+  private readonly unhealthyAfter: number;
+  private readonly probeTimeoutMs: number;
+  private readonly now: () => Date;
+  private readonly scheduler: HealthScheduler;
+  private readonly onError?: (providerName: string, error: unknown) => void;
+
+  constructor(options: ProviderHealthTrackerOptions = {}) {
+    this.intervalMs = options.intervalMs ?? 30_000;
+    this.unhealthyAfter = options.unhealthyAfter ?? 3;
+    this.probeTimeoutMs = options.probeTimeoutMs ?? 5_000;
+    this.now = options.now ?? (() => new Date());
+    this.scheduler = options.scheduler ?? defaultScheduler;
+    this.onError = options.onError;
+  }
+
+  /**
+   * Register a provider for tracking. Providers without `healthCheck()` are recorded but always
+   * reported as healthy (graceful).
+   */
+  track(provider: ICapabilityProvider): void {
+    if (this.providers.has(provider.name)) return;
+    this.providers.set(provider.name, provider);
+    this.state.set(provider.name, {
+      name: provider.name,
+      healthy: true,
+      consecutiveFailures: 0,
+      latencySamplesMs: [],
+    });
+  }
+
+  /** Stop tracking a provider (e.g. on hot unregister). */
+  untrack(name: string): void {
+    this.providers.delete(name);
+    this.state.delete(name);
+  }
+
+  /** Required by `HealthOracle`. */
+  isHealthy(providerName: string): boolean {
+    const s = this.state.get(providerName);
+    if (!s) return true; // not tracked = no data = assume healthy
+    return s.healthy;
+  }
+
+  /**
+   * Start the polling loop. Idempotent — calling twice is a no-op.
+   * Does NOT block: returns immediately after scheduling.
+   */
+  start(): void {
+    if (this.handle) return;
+    this.handle = this.scheduler.start(() => {
+      void this.probeAll();
+    }, this.intervalMs);
+  }
+
+  /** Stop polling. Safe to call before `start`. */
+  stop(): void {
+    this.handle?.stop();
+    this.handle = undefined;
+  }
+
+  /**
+   * Manually mark a provider unhealthy with a reason. Used by the facade when a provider error
+   * indicates the provider itself is degraded (not just a per-request failure).
+   */
+  markUnhealthy(name: string, reason: string): void {
+    const s = this.state.get(name);
+    if (!s) return;
+    s.healthy = false;
+    s.consecutiveFailures = Math.max(s.consecutiveFailures, this.unhealthyAfter);
+    s.lastProbe = {
+      healthy: false,
+      reason,
+      checkedAt: this.now().toISOString(),
+    };
+  }
+
+  /**
+   * Manually mark a provider healthy. Used when an external signal proves the provider is back.
+   */
+  markHealthy(name: string): void {
+    const s = this.state.get(name);
+    if (!s) return;
+    s.healthy = true;
+    s.consecutiveFailures = 0;
+    s.lastProbe = { healthy: true, checkedAt: this.now().toISOString() };
+  }
+
+  /**
+   * Snapshot of current health for every tracked provider. Useful for the discovery endpoint.
+   */
+  snapshot(): Map<string, ProviderHealth> {
+    const out = new Map<string, ProviderHealth>();
+    for (const [name, s] of this.state) {
+      if (!s.lastProbe) continue;
+      out.set(name, { ...s.lastProbe });
+    }
+    return out;
+  }
+
+  /**
+   * Aggregated report for `/v1/capability/monitoring/...` (consumed by `monitoring-service`).
+   */
+  report(): ProviderHealthReport[] {
+    return [...this.state.values()].map((s) => ({
+      name: s.name,
+      healthy: s.healthy,
+      consecutiveFailures: s.consecutiveFailures,
+      ...(s.latencySamplesMs.length > 0 && {
+        latencyP95Ms: percentile(s.latencySamplesMs, 95),
+      }),
+      ...(s.lastProbe?.checkedAt && { lastCheckedAt: s.lastProbe.checkedAt }),
+      ...(s.lastProbe?.reason && { lastReason: s.lastProbe.reason }),
+    }));
+  }
+
+  /**
+   * Force a probe sweep right now. Useful for tests, for `/health` endpoints that want fresh data,
+   * and for the initial health hydration after boot.
+   */
+  async probeAll(): Promise<void> {
+    const ops = [...this.providers.values()].map((p) => this.probeOne(p));
+    await Promise.all(ops);
+  }
+
+  /**
+   * Probe a single provider. Public to allow targeted re-probe after a known incident.
+   */
+  async probeOne(provider: ICapabilityProvider): Promise<void> {
+    const s = this.state.get(provider.name);
+    if (!s) return;
+
+    if (!provider.healthCheck) {
+      // No probe available — treat as continuously healthy without spending any sample slot.
+      s.healthy = true;
+      s.consecutiveFailures = 0;
+      return;
+    }
+
+    const startedAt = Date.now();
+    let probe: ProviderHealth;
+    try {
+      probe = await withTimeout(provider.healthCheck(), this.probeTimeoutMs);
+    } catch (e) {
+      this.onError?.(provider.name, e);
+      probe = {
+        healthy: false,
+        reason: asMessage(e),
+        latencyMs: Date.now() - startedAt,
+        checkedAt: this.now().toISOString(),
+      };
+    }
+
+    // Normalise checkedAt
+    if (!probe.checkedAt) probe = { ...probe, checkedAt: this.now().toISOString() };
+    s.lastProbe = probe;
+    if (typeof probe.latencyMs === "number") {
+      s.latencySamplesMs.push(probe.latencyMs);
+      if (s.latencySamplesMs.length > LATENCY_WINDOW) s.latencySamplesMs.shift();
+    }
+
+    if (probe.healthy) {
+      s.healthy = true;
+      s.consecutiveFailures = 0;
+    } else {
+      s.consecutiveFailures += 1;
+      if (s.consecutiveFailures >= this.unhealthyAfter) {
+        s.healthy = false;
+      }
+    }
+  }
+}
+
+// -------------------------------------------------------------------------------------------------
+// Helpers
+// -------------------------------------------------------------------------------------------------
+
+function withTimeout<T>(p: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  return Promise.race([
+    p.then(
+      (v) => {
+        if (timer) clearTimeout(timer);
+        return v;
+      },
+      (e) => {
+        if (timer) clearTimeout(timer);
+        throw e;
+      }
+    ),
+    new Promise<T>((_, reject) => {
+      timer = setTimeout(() => reject(new Error(`healthCheck timed out after ${ms}ms`)), ms);
+    }),
+  ]);
+}
+
+function percentile(samples: number[], p: number): number {
+  const sorted = [...samples].sort((a, b) => a - b);
+  const idx = Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1));
+  return sorted[idx] as number;
+}
+
+function asMessage(e: unknown): string {
+  if (e instanceof Error) return e.message;
+  if (typeof e === "string") return e;
+  try {
+    return JSON.stringify(e);
+  } catch {
+    return "<unserialisable error>";
+  }
+}

--- a/shared/capability/http/__tests__/discovery.handler.test.ts
+++ b/shared/capability/http/__tests__/discovery.handler.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { createDiscoveryHandler } from "../discovery.handler";
+import type { ICapabilityProvider, ProviderHealth } from "../../provider.types";
+
+function provider(input: {
+  name: string;
+  capability?: "swap" | "lending" | "staking";
+  supportedChains?: number[];
+}): ICapabilityProvider {
+  return {
+    name: input.name,
+    metadata: {
+      name: input.name,
+      capability: input.capability ?? "swap",
+      supportedChains: input.supportedChains ?? [1],
+      version: "1.0.0",
+    },
+  };
+}
+
+const TRACE = "trace-abc-123";
+
+function fixedTime() {
+  let current = new Date("2026-05-22T00:00:00Z").getTime();
+  return {
+    now: () => new Date(current),
+    advance(ms: number) {
+      current += ms;
+    },
+  };
+}
+
+describe("discovery.handler — basic shape", () => {
+  it("returns a success envelope wrapping AvailabilityMap", () => {
+    const clock = fixedTime();
+    const handler = createDiscoveryHandler({
+      listProviders: () => [provider({ name: "uniswap" })],
+      now: clock.now,
+    });
+    const res = handler({ traceId: TRACE });
+    expect(res.status).toBe("success");
+    expect(res.traceId).toBe(TRACE);
+    expect(res.provider.name).toBe("discovery");
+    expect(res.data.capabilities).toHaveLength(1);
+    expect(res.data.cacheTtlSeconds).toBe(30);
+    expect(res.data.generatedAt).toBe("2026-05-22T00:00:00.000Z");
+  });
+
+  it("honours custom cacheTtlSeconds", () => {
+    const clock = fixedTime();
+    const handler = createDiscoveryHandler({
+      listProviders: () => [],
+      cacheTtlSeconds: 5,
+      now: clock.now,
+    });
+    const res = handler({ traceId: TRACE });
+    expect(res.data.cacheTtlSeconds).toBe(5);
+  });
+});
+
+describe("discovery.handler — caching", () => {
+  it("uses cached snapshot within TTL", () => {
+    const clock = fixedTime();
+    const listProviders = vi.fn(() => [provider({ name: "uniswap" })]);
+    const handler = createDiscoveryHandler({
+      listProviders,
+      cacheTtlSeconds: 30,
+      now: clock.now,
+    });
+
+    handler({ traceId: TRACE });
+    clock.advance(10_000); // 10s later, within TTL
+    handler({ traceId: TRACE });
+
+    expect(listProviders).toHaveBeenCalledOnce();
+  });
+
+  it("rebuilds after TTL expires", () => {
+    const clock = fixedTime();
+    const listProviders = vi.fn(() => [provider({ name: "uniswap" })]);
+    const handler = createDiscoveryHandler({
+      listProviders,
+      cacheTtlSeconds: 30,
+      now: clock.now,
+    });
+
+    handler({ traceId: TRACE });
+    clock.advance(31_000); // past TTL
+    handler({ traceId: TRACE });
+
+    expect(listProviders).toHaveBeenCalledTimes(2);
+  });
+
+  it("force: true bypasses cache", () => {
+    const clock = fixedTime();
+    const listProviders = vi.fn(() => [provider({ name: "uniswap" })]);
+    const handler = createDiscoveryHandler({
+      listProviders,
+      cacheTtlSeconds: 30,
+      now: clock.now,
+    });
+
+    handler({ traceId: TRACE });
+    handler({ traceId: TRACE, force: true });
+
+    expect(listProviders).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidate() drops the cached snapshot", () => {
+    const clock = fixedTime();
+    const listProviders = vi.fn(() => []);
+    const handler = createDiscoveryHandler({
+      listProviders,
+      now: clock.now,
+    });
+
+    handler({ traceId: TRACE });
+    handler.invalidate();
+    handler({ traceId: TRACE });
+
+    expect(listProviders).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("discovery.handler — health overlay", () => {
+  it("includes health from snapshotHealth", () => {
+    const clock = fixedTime();
+    const handler = createDiscoveryHandler({
+      listProviders: () => [
+        provider({ name: "uniswap", supportedChains: [1] }),
+        provider({ name: "aerodrome", capability: "swap", supportedChains: [8453] }),
+      ],
+      snapshotHealth: () =>
+        new Map<string, ProviderHealth>([
+          [
+            "aerodrome",
+            { healthy: false, reason: "rate-limit", latencyMs: 100, checkedAt: "x" },
+          ],
+        ]),
+      now: clock.now,
+    });
+    const res = handler({ traceId: TRACE });
+    const swap = res.data.capabilities[0];
+    const aero = swap?.byChain[8453]?.[0];
+    expect(aero?.healthy).toBe(false);
+    expect(aero?.lastError).toBe("rate-limit");
+  });
+
+  it("defaults to healthy when no snapshot", () => {
+    const handler = createDiscoveryHandler({
+      listProviders: () => [provider({ name: "uniswap" })],
+    });
+    const res = handler({ traceId: TRACE });
+    expect(res.data.capabilities[0]?.byChain[1]?.[0]?.healthy).toBe(true);
+  });
+});
+
+describe("discovery.handler — envelope details", () => {
+  it("reports latencyMs ≥ 0", () => {
+    const handler = createDiscoveryHandler({ listProviders: () => [] });
+    const res = handler({ traceId: TRACE });
+    expect(res.latencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("propagates traceId verbatim", () => {
+    const handler = createDiscoveryHandler({ listProviders: () => [] });
+    const res = handler({ traceId: "my-custom-trace" });
+    expect(res.traceId).toBe("my-custom-trace");
+  });
+});

--- a/shared/capability/http/discovery.handler.ts
+++ b/shared/capability/http/discovery.handler.ts
@@ -1,0 +1,120 @@
+/**
+ * Discovery handler — framework-agnostic.
+ *
+ * The handler builds an `AvailabilityMap` from a registry snapshot + health snapshot, caches it
+ * for `cacheTtlSeconds`, and returns a `CapabilitySuccessResponse<AvailabilityMap>` ready to
+ * serialise. The HTTP layer wraps it in the framework of choice:
+ *
+ *     // Express
+ *     app.get('/v1/capability/_discovery', async (req, res) => {
+ *       const result = await handler({ traceId: req.id, source: 'all' });
+ *       res.status(200).json(result);
+ *     });
+ *
+ *     // Fastify
+ *     fastify.get('/v1/capability/_discovery', async (req) => handler({ traceId: req.id }));
+ *
+ * Card #207 (SPRINT_HUGO.md).
+ */
+
+import {
+  buildAvailabilityMap,
+  type AvailabilityMap,
+} from "../availability.types";
+import { buildSuccess, type CapabilitySuccessResponse, type Uuid } from "../envelope.types";
+import type { ICapabilityProvider, ProviderHealth } from "../provider.types";
+
+// -------------------------------------------------------------------------------------------------
+// Dependencies the handler needs — framework-agnostic surface.
+// -------------------------------------------------------------------------------------------------
+
+export interface DiscoveryHandlerDeps {
+  /**
+   * Source of providers. Typically `() => registry.listAll({ includeDisabled: false })` but a
+   * service may federate across multiple registries (e.g. portfolio-service queries others).
+   */
+  listProviders: () => ICapabilityProvider[];
+
+  /**
+   * Source of latest health probes keyed by provider name. Typically `() => healthTracker.snapshot()`.
+   * Optional — when absent, all providers are treated as healthy.
+   */
+  snapshotHealth?: () => Map<string, ProviderHealth>;
+
+  /** TTL the FE / gateway can cache. Default 30s. */
+  cacheTtlSeconds?: number;
+
+  /** Injectable clock for tests. */
+  now?: () => Date;
+}
+
+// -------------------------------------------------------------------------------------------------
+// Handler input/output
+// -------------------------------------------------------------------------------------------------
+
+export interface DiscoveryHandlerInput {
+  /** Trace id from the request — propagated into the response envelope. */
+  traceId: Uuid;
+  /**
+   * When `force: true`, bypass the in-memory cache and rebuild. Used by ops for diagnostic
+   * snapshots after a known incident.
+   */
+  force?: boolean;
+}
+
+export type DiscoveryHandlerOutput = CapabilitySuccessResponse<AvailabilityMap>;
+
+// -------------------------------------------------------------------------------------------------
+// Factory — captures deps + cache state
+// -------------------------------------------------------------------------------------------------
+
+export interface DiscoveryHandler {
+  (input: DiscoveryHandlerInput): DiscoveryHandlerOutput;
+  /** Drop the cached snapshot. The next call rebuilds. */
+  invalidate(): void;
+}
+
+/**
+ * Create a discovery handler. Each service composition root creates one and mounts it.
+ *
+ * The handler is **synchronous** — building the availability map is pure CPU. Network calls
+ * (health probes) happen out of band in the `ProviderHealthTracker`.
+ */
+export function createDiscoveryHandler(deps: DiscoveryHandlerDeps): DiscoveryHandler {
+  const cacheTtlSeconds = deps.cacheTtlSeconds ?? 30;
+  const now = deps.now ?? (() => new Date());
+
+  let cached: AvailabilityMap | null = null;
+  let cachedAtMs = 0;
+
+  const handler = ((input: DiscoveryHandlerInput) => {
+    const start = now().getTime();
+
+    const expired = !cached || start - cachedAtMs > cacheTtlSeconds * 1000;
+    if (expired || input.force) {
+      const map = buildAvailabilityMap({
+        providers: deps.listProviders(),
+        ...(deps.snapshotHealth && { healthByName: deps.snapshotHealth() }),
+        cacheTtlSeconds,
+        now: deps.now,
+      });
+      cached = map;
+      cachedAtMs = start;
+    }
+
+    const latencyMs = now().getTime() - start;
+    return buildSuccess({
+      data: cached!,
+      provider: { name: "discovery" },
+      traceId: input.traceId,
+      latencyMs,
+    });
+  }) as DiscoveryHandler;
+
+  handler.invalidate = () => {
+    cached = null;
+    cachedAtMs = 0;
+  };
+
+  return handler;
+}

--- a/shared/capability/index.ts
+++ b/shared/capability/index.ts
@@ -48,3 +48,67 @@ export type {
 } from "./availability.types";
 
 export { buildAvailabilityMap } from "./availability.types";
+
+// Registry: generic container that holds providers per capability.
+export { ProviderRegistry } from "./registry";
+export type {
+  RegistryListFilter,
+  RegistryEvent,
+  RegistryListener,
+  ListByChainOptions,
+  HealthOracle,
+} from "./registry.types";
+
+// Registry config loader: instantiate providers from a JSON config + a factory.
+export {
+  loadProvidersFromConfig,
+  type ProviderConfigEntry,
+  type ProviderConfigFile,
+  type ProviderFactory,
+  type LoaderOptions,
+  type LoaderResult,
+} from "./registry.loader";
+
+// Priority policy + the iterate/fallback helper used by every capability facade.
+export {
+  ChainAssetPriorityPolicy,
+  fallbackInvoke,
+  type IPriorityPolicy,
+  type PolicyContext,
+  type ChainAssetPriorityConfig,
+  type ChainPriorityEntry,
+  type PerChainAssetMap,
+  type PerChainList,
+  type FallbackInvokeInput,
+  type FallbackInvokeOutcome,
+  type FallbackInvokeSuccess,
+  type FallbackInvokeFailure,
+  type FallbackAttempt,
+} from "./policy";
+
+// Provider limitations + applyLimitations check.
+export {
+  applyLimitations,
+  compareDecimalStrings,
+  type ProviderLimitations,
+  type LimitationCheckInput,
+  type LimitationResult,
+} from "./provider-limitations";
+
+// Health tracker: periodic probes + HealthOracle implementation.
+export {
+  ProviderHealthTracker,
+  type ProviderHealthTrackerOptions,
+  type ProviderHealthReport,
+  type HealthScheduler,
+  type HealthSchedulerHandle,
+} from "./health";
+
+// Discovery handler factory — framework-agnostic.
+export {
+  createDiscoveryHandler,
+  type DiscoveryHandler,
+  type DiscoveryHandlerDeps,
+  type DiscoveryHandlerInput,
+  type DiscoveryHandlerOutput,
+} from "./http/discovery.handler";

--- a/shared/capability/policies/chain-asset-priority.policy.ts
+++ b/shared/capability/policies/chain-asset-priority.policy.ts
@@ -1,0 +1,15 @@
+/**
+ * Re-export of `ChainAssetPriorityPolicy` at the canonical sub-path consumers may import via
+ * `@panorama/capability/policies/chain-asset-priority.policy`.
+ *
+ * The implementation lives in `../policy.ts` because the class is small and the fallback
+ * iteration helper sits next to it — splitting them across modules would force more cross-imports
+ * with no clarity gain.
+ */
+export {
+  ChainAssetPriorityPolicy,
+  type ChainAssetPriorityConfig,
+  type ChainPriorityEntry,
+  type PerChainAssetMap,
+  type PerChainList,
+} from "../policy";

--- a/shared/capability/policy.ts
+++ b/shared/capability/policy.ts
@@ -1,0 +1,280 @@
+/**
+ * Priority policy abstraction.
+ *
+ * A policy ranks providers for a given request context. The facade of each capability calls
+ *
+ *     const ranked = policy.rank(providers, requestContext);
+ *
+ * then iterates `ranked` in order. The default policy is `ChainAssetPriorityPolicy` (config-driven
+ * by chain id), but the abstraction allows specialised policies (cost-aware, latency-aware,
+ * tenant-pinned, etc.) without touching the facade.
+ *
+ * The fallback iteration (call `supportsRoute`, attempt action, catch, move on) lives in
+ * `fallbackInvoke` below — extracted from the existing
+ * `liquid-swap-service/.../provider-selector.service.ts:201-242`.
+ */
+
+import { CapabilityError, ErrorCategory } from "./errors";
+import type { ICapabilityProvider } from "./provider.types";
+
+// -------------------------------------------------------------------------------------------------
+// Policy interface
+// -------------------------------------------------------------------------------------------------
+
+/**
+ * A request context handed to the policy. Capabilities specialise this:
+ *  - Swap context carries `fromAsset`, `toAsset`, `fromChainId`, `toChainId`.
+ *  - Lending context carries `asset`, `chainId`, `action: 'supply' | 'borrow'`.
+ * The policy uses a subset of the fields it needs and ignores the rest.
+ */
+export interface PolicyContext {
+  chainId: number;
+  /** Optional secondary chain — used by cross-chain capabilities (bridge). */
+  destinationChainId?: number;
+  /** Optional asset tag — used by asset-aware policies. */
+  asset?: string;
+  /** Free-form fields for specialised policies. */
+  [k: string]: unknown;
+}
+
+export interface IPriorityPolicy {
+  /**
+   * Rank candidates for the given context. The returned array is a permutation of the input
+   * (no provider added or removed). Providers not mentioned by the policy go last in stable order.
+   */
+  rank<TProvider extends ICapabilityProvider>(
+    providers: readonly TProvider[],
+    context: PolicyContext
+  ): TProvider[];
+}
+
+// -------------------------------------------------------------------------------------------------
+// ChainAssetPriorityPolicy — config-driven by chain (and optional asset prefix)
+// -------------------------------------------------------------------------------------------------
+
+/**
+ * Config shape for `ChainAssetPriorityPolicy`. Either pass a flat per-chain priority map, or a
+ * nested per-chain-per-asset map for finer control.
+ *
+ *     {
+ *       "8453": ["aerodrome", "uniswap-trading-api", "uniswap", "thirdweb"],
+ *       "1":    ["uniswap-trading-api", "uniswap", "thirdweb"],
+ *       "default-cross-chain": ["thirdweb", "uniswap-trading-api", "uniswap"]
+ *     }
+ *
+ * Or with asset-specific overrides:
+ *
+ *     {
+ *       "8453": {
+ *         "default": ["aerodrome", "uniswap"],
+ *         "by-asset": { "USDC": ["uniswap", "aerodrome"] }
+ *       }
+ *     }
+ */
+export type PerChainList = string[];
+export interface PerChainAssetMap {
+  default: string[];
+  "by-asset"?: Record<string, string[]>;
+}
+export type ChainPriorityEntry = PerChainList | PerChainAssetMap;
+
+export interface ChainAssetPriorityConfig {
+  /** Keyed by chainId-as-string. Special key `"default-cross-chain"` for context with `destinationChainId !== chainId`. */
+  [chainIdOrSpecial: string]: ChainPriorityEntry;
+}
+
+const CROSS_CHAIN_KEY = "default-cross-chain";
+const DEFAULT_KEY = "default";
+
+export class ChainAssetPriorityPolicy implements IPriorityPolicy {
+  constructor(private readonly config: ChainAssetPriorityConfig) {
+    if (!config || typeof config !== "object") {
+      throw new CapabilityError({
+        code: "CAPABILITY_POLICY_INVALID_CONFIG",
+        category: ErrorCategory.INTERNAL,
+        message: "ChainAssetPriorityPolicy requires a config object",
+      });
+    }
+  }
+
+  rank<TProvider extends ICapabilityProvider>(
+    providers: readonly TProvider[],
+    context: PolicyContext
+  ): TProvider[] {
+    const order = this.resolveOrder(context);
+    if (order.length === 0) {
+      return [...providers]; // No opinion — preserve registration order.
+    }
+
+    const orderIndex = new Map<string, number>();
+    for (let i = 0; i < order.length; i++) orderIndex.set(order[i] as string, i);
+
+    // Stable sort: ranked-by-policy first (by index), then the rest in their original order.
+    const withIndex = providers.map((p, original) => ({
+      p,
+      rank: orderIndex.get(p.name) ?? Number.POSITIVE_INFINITY,
+      original,
+    }));
+    withIndex.sort((a, b) => {
+      if (a.rank !== b.rank) return a.rank - b.rank;
+      return a.original - b.original;
+    });
+    return withIndex.map((x) => x.p);
+  }
+
+  /**
+   * Resolve the priority list for a given context.
+   * Lookup order:
+   *  1. If context has `destinationChainId !== chainId`, use `default-cross-chain`.
+   *  2. Look up `config[chainId.toString()]`.
+   *  3. If that entry is a `PerChainAssetMap`, check `by-asset[context.asset]`, then fall back
+   *     to `default`.
+   *  4. If no match, return an empty list (= no opinion).
+   */
+  private resolveOrder(context: PolicyContext): string[] {
+    if (
+      typeof context.destinationChainId === "number" &&
+      context.destinationChainId !== context.chainId
+    ) {
+      const cross = this.config[CROSS_CHAIN_KEY];
+      if (cross) return flattenEntry(cross, context.asset);
+    }
+    const entry = this.config[String(context.chainId)];
+    if (!entry) return [];
+    return flattenEntry(entry, context.asset);
+  }
+}
+
+function flattenEntry(entry: ChainPriorityEntry, asset?: string): string[] {
+  if (Array.isArray(entry)) return entry;
+  if (asset && entry["by-asset"]?.[asset]) return entry["by-asset"][asset]!;
+  return entry[DEFAULT_KEY] ?? [];
+}
+
+// -------------------------------------------------------------------------------------------------
+// fallbackInvoke — the iterate-rank-supportsRoute-call dance, generalised
+// -------------------------------------------------------------------------------------------------
+
+export interface FallbackInvokeInput<TProvider extends ICapabilityProvider, TResult> {
+  /** Already ranked by the policy. */
+  ranked: readonly TProvider[];
+  /** Async predicate that asks the provider whether it can serve this route. */
+  supportsRoute: (provider: TProvider) => Promise<boolean>;
+  /** The work to perform once a supporting provider is found. */
+  invoke: (provider: TProvider) => Promise<TResult>;
+  /** Capability slug used to build the `CapabilityError` if all fail. */
+  capability: string;
+  /**
+   * Optional classifier — given an error from `invoke`, decide whether to:
+   *  - `'fallback'` (default): try the next provider.
+   *  - `'rethrow'`: bubble up immediately (e.g. validation errors that no provider can fix).
+   */
+  shouldFallback?: (error: unknown, provider: TProvider) => "fallback" | "rethrow";
+}
+
+export interface FallbackAttempt {
+  provider: string;
+  reason: string;
+}
+
+export interface FallbackInvokeSuccess<TResult, TProvider> {
+  ok: true;
+  result: TResult;
+  provider: TProvider;
+  attempts: FallbackAttempt[];
+}
+
+export interface FallbackInvokeFailure {
+  ok: false;
+  error: CapabilityError;
+  attempts: FallbackAttempt[];
+}
+
+export type FallbackInvokeOutcome<TResult, TProvider> =
+  | FallbackInvokeSuccess<TResult, TProvider>
+  | FallbackInvokeFailure;
+
+/**
+ * Iterate ranked providers, calling the first one that `supportsRoute`. If it fails (and the
+ * error is classified as `fallback`), try the next. Returns a result with the full attempts trail.
+ *
+ * On total failure, throws `CapabilityError.allProvidersFailed`. The caller can choose to
+ * return the failure record or rethrow.
+ *
+ * @example
+ *   const outcome = await fallbackInvoke({
+ *     ranked, supportsRoute: p => p.supportsRoute(req),
+ *     invoke: p => p.prepareSwap(req),
+ *     capability: 'swap',
+ *   });
+ *   if (outcome.ok) return outcome.result;
+ *   throw outcome.error;
+ */
+export async function fallbackInvoke<TProvider extends ICapabilityProvider, TResult>(
+  input: FallbackInvokeInput<TProvider, TResult>
+): Promise<FallbackInvokeOutcome<TResult, TProvider>> {
+  const attempts: FallbackAttempt[] = [];
+  const shouldFallback =
+    input.shouldFallback ?? defaultShouldFallback;
+
+  for (const provider of input.ranked) {
+    let supports: boolean;
+    try {
+      supports = await input.supportsRoute(provider);
+    } catch (e) {
+      attempts.push({ provider: provider.name, reason: `supportsRoute threw: ${asMessage(e)}` });
+      continue;
+    }
+    if (!supports) {
+      attempts.push({ provider: provider.name, reason: "route unsupported" });
+      continue;
+    }
+
+    try {
+      const result = await input.invoke(provider);
+      return { ok: true, result, provider, attempts };
+    } catch (e) {
+      const decision = shouldFallback(e, provider);
+      attempts.push({ provider: provider.name, reason: asMessage(e) });
+      if (decision === "rethrow") {
+        if (CapabilityError.is(e)) throw e;
+        throw CapabilityError.providerFailure({
+          capability: input.capability,
+          provider: provider.name,
+          message: asMessage(e),
+          cause: e,
+        });
+      }
+    }
+  }
+
+  const error = CapabilityError.allProvidersFailed({
+    capability: input.capability,
+    attempts: attempts.map((a) => ({ provider: a.provider, error: a.reason })),
+  });
+  return { ok: false, error, attempts };
+}
+
+function defaultShouldFallback(error: unknown): "fallback" | "rethrow" {
+  if (CapabilityError.is(error)) {
+    // Don't fall back on errors that no other provider can fix.
+    switch (error.category) {
+      case ErrorCategory.VALIDATION:
+      case ErrorCategory.UNSUPPORTED_ROUTE:
+        return "rethrow";
+      default:
+        return "fallback";
+    }
+  }
+  return "fallback";
+}
+
+function asMessage(e: unknown): string {
+  if (e instanceof Error) return e.message;
+  if (typeof e === "string") return e;
+  try {
+    return JSON.stringify(e);
+  } catch {
+    return "<unserialisable error>";
+  }
+}

--- a/shared/capability/provider-limitations.ts
+++ b/shared/capability/provider-limitations.ts
@@ -1,0 +1,162 @@
+/**
+ * Provider limitations — per-provider caps on amounts, blocked tokens/chains, daily volume.
+ *
+ * Today these live scattered inside adapter implementations (hard-coded `if (amount > MAX) throw`).
+ * This module gives every provider a declarative way to surface its caps; the capability facade
+ * (or a middleware) calls `applyLimitations` before delegating to the provider and converts a
+ * violation into a `CapabilityError(VALIDATION)` with structured details.
+ *
+ * Card #208 (SPRINT_HUGO.md).
+ */
+
+import { CapabilityError } from "./errors";
+
+// -------------------------------------------------------------------------------------------------
+// The limitations shape — usually carried inside `ProviderMetadata.features` or via a separate
+// adapter property; both work, this module doesn't impose a placement.
+// -------------------------------------------------------------------------------------------------
+
+export interface ProviderLimitations {
+  /** Asset → max amount (wei as decimal string). Inclusive lower bound is `minAmountByAsset`. */
+  maxAmountByAsset?: Record<string, string>;
+  /** Asset → min amount (wei as decimal string). */
+  minAmountByAsset?: Record<string, string>;
+  /** Tokens (by symbol or address) that this provider refuses outright. */
+  blockedTokens?: string[];
+  /** Chains the provider declines to operate on (overrides `supportedChains` for runtime ops). */
+  blockedChains?: number[];
+  /** Hard cap on daily USD volume per tenant. Enforced by the caller; this module only reports. */
+  dailyVolumeLimitUsd?: number;
+  /** Free-form labels for ops (e.g. "kyc-required"). The capability code may inspect these. */
+  flags?: string[];
+}
+
+// -------------------------------------------------------------------------------------------------
+// Input handed to applyLimitations
+// -------------------------------------------------------------------------------------------------
+
+export interface LimitationCheckInput {
+  capability: string;
+  provider: string;
+  limitations: ProviderLimitations;
+  /** The asset being moved/affected — symbol or address; whatever the limitations are keyed by. */
+  asset?: string;
+  /** Amount in wei as decimal string. */
+  amount?: string;
+  chainId?: number;
+  /** Cumulative USD volume the caller has already done today; provider checks against limit. */
+  todayVolumeUsd?: number;
+}
+
+// -------------------------------------------------------------------------------------------------
+// Result
+// -------------------------------------------------------------------------------------------------
+
+export type LimitationOk = { ok: true };
+export type LimitationErr = { ok: false; error: CapabilityError };
+export type LimitationResult = LimitationOk | LimitationErr;
+
+// -------------------------------------------------------------------------------------------------
+// Implementation
+// -------------------------------------------------------------------------------------------------
+
+/**
+ * Run the registered limitation checks. Returns a tagged result rather than throwing so the
+ * caller can choose to convert into HTTP error vs collect multiple violations.
+ *
+ * Violations are surfaced with the most specific category available:
+ *  - blockedTokens / blockedChains / amount out of range → VALIDATION
+ *  - dailyVolumeLimitUsd exceeded → RATE_LIMITED (the user can retry tomorrow)
+ */
+export function applyLimitations(input: LimitationCheckInput): LimitationResult {
+  const { capability, provider, limitations, asset, amount, chainId, todayVolumeUsd } = input;
+
+  if (asset && limitations.blockedTokens?.includes(asset)) {
+    return {
+      ok: false,
+      error: CapabilityError.validation({
+        capability,
+        message: `Provider "${provider}" does not support asset "${asset}"`,
+        errors: [{ field: "asset", reason: "blocked", value: asset }],
+      }),
+    };
+  }
+
+  if (typeof chainId === "number" && limitations.blockedChains?.includes(chainId)) {
+    return {
+      ok: false,
+      error: CapabilityError.validation({
+        capability,
+        message: `Provider "${provider}" refuses operations on chain ${chainId}`,
+        errors: [{ field: "chainId", reason: "blocked", value: chainId }],
+      }),
+    };
+  }
+
+  if (typeof amount === "string" && asset) {
+    const max = limitations.maxAmountByAsset?.[asset];
+    if (max && compareDecimalStrings(amount, max) > 0) {
+      return {
+        ok: false,
+        error: CapabilityError.validation({
+          capability,
+          message: `Amount ${amount} for "${asset}" exceeds provider "${provider}" max ${max}`,
+          errors: [{ field: "amount", reason: "above-max", value: amount, max }],
+        }),
+      };
+    }
+    const min = limitations.minAmountByAsset?.[asset];
+    if (min && compareDecimalStrings(amount, min) < 0) {
+      return {
+        ok: false,
+        error: CapabilityError.validation({
+          capability,
+          message: `Amount ${amount} for "${asset}" below provider "${provider}" min ${min}`,
+          errors: [{ field: "amount", reason: "below-min", value: amount, min }],
+        }),
+      };
+    }
+  }
+
+  if (
+    typeof todayVolumeUsd === "number" &&
+    typeof limitations.dailyVolumeLimitUsd === "number" &&
+    todayVolumeUsd >= limitations.dailyVolumeLimitUsd
+  ) {
+    return {
+      ok: false,
+      error: CapabilityError.rateLimited({
+        capability,
+        provider,
+      }),
+    };
+  }
+
+  return { ok: true };
+}
+
+// -------------------------------------------------------------------------------------------------
+// Decimal-string comparison (avoid BigInt to keep this module dep-free; amounts are wei as string)
+// -------------------------------------------------------------------------------------------------
+
+/**
+ * Compare two non-negative decimal integer strings. Returns -1, 0, 1.
+ * Throws if either string isn't a digits-only sequence (allows trimming + leading zeros).
+ */
+export function compareDecimalStrings(a: string, b: string): number {
+  const aClean = stripLeadingZeros(a.trim());
+  const bClean = stripLeadingZeros(b.trim());
+  if (!/^\d+$/.test(aClean) || !/^\d+$/.test(bClean)) {
+    throw new Error(
+      `compareDecimalStrings: expected non-negative digits-only strings, got ${JSON.stringify(a)} vs ${JSON.stringify(b)}`
+    );
+  }
+  if (aClean.length !== bClean.length) return aClean.length - bClean.length > 0 ? 1 : -1;
+  if (aClean === bClean) return 0;
+  return aClean > bClean ? 1 : -1;
+}
+
+function stripLeadingZeros(s: string): string {
+  const stripped = s.replace(/^0+/, "");
+  return stripped.length === 0 ? "0" : stripped;
+}

--- a/shared/capability/registry.loader.ts
+++ b/shared/capability/registry.loader.ts
@@ -1,0 +1,235 @@
+/**
+ * Config-driven provider registration.
+ *
+ * Each service ships a `config/providers.<env>.json` enumerating the providers to register and
+ * a per-provider `enabled` flag. At boot, the DI container calls `loadProvidersFromConfig` with
+ * the registry and a factory that knows how to instantiate the concrete adapter for a given name.
+ *
+ *     loadProvidersFromConfig(registry, {
+ *       configPath: 'config/providers.production.json',
+ *       factory: (entry) => buildProvider(entry),  // service-specific
+ *     });
+ *
+ * Why a factory:
+ *  - Adapters often need dependencies (RPC client, API keys, contract addresses) that the
+ *    registry/loader has no opinion on. The service composition root knows.
+ *  - This keeps the loader framework-agnostic and testable.
+ *
+ * See CONVENTIONS.md and card #205 (SPRINT_HUGO.md).
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { CapabilityError, ErrorCategory } from "./errors";
+import type { ICapabilityProvider, ProviderMetadata } from "./provider.types";
+import { isCapabilitySlug, validateProviderMetadata } from "./provider.types";
+import type { ProviderRegistry } from "./registry";
+
+// -------------------------------------------------------------------------------------------------
+// Config shape — what lives on disk
+// -------------------------------------------------------------------------------------------------
+
+export interface ProviderConfigEntry {
+  name: string;
+  capability: string;
+  supportedChains: number[];
+  features?: string[];
+  version: string;
+  enabled?: boolean;
+  /**
+   * Optional adapter-specific configuration bag. The loader does not inspect it; the factory
+   * receives the entry and may pull from `.options`.
+   */
+  options?: Record<string, unknown>;
+}
+
+export interface ProviderConfigFile {
+  providers: ProviderConfigEntry[];
+}
+
+// -------------------------------------------------------------------------------------------------
+// Loader input
+// -------------------------------------------------------------------------------------------------
+
+/**
+ * A factory that turns one config entry into a concrete provider instance.
+ * The service composition root provides this — it owns the knowledge of how to construct each
+ * adapter (RPC client, contract addresses, API keys, etc).
+ *
+ * Returning `null` skips the entry without erroring (useful for "this adapter isn't implemented
+ * in this binary"). Throwing signals a misconfiguration and aborts the load.
+ */
+export type ProviderFactory<TProvider extends ICapabilityProvider> = (
+  entry: ProviderConfigEntry
+) => TProvider | null;
+
+export interface LoaderOptions<TProvider extends ICapabilityProvider> {
+  /** Either pass `configPath` (read from disk) or `config` (already parsed). */
+  configPath?: string;
+  config?: ProviderConfigFile;
+  factory: ProviderFactory<TProvider>;
+  /**
+   * Skip disabled entries. Default `true`. When `false`, disabled entries are still passed to
+   * the factory but the registry will keep `metadata.enabled = false` and exclude them by default
+   * from `listByChain`.
+   */
+  skipDisabled?: boolean;
+}
+
+// -------------------------------------------------------------------------------------------------
+// Result
+// -------------------------------------------------------------------------------------------------
+
+export interface LoaderResult {
+  registered: string[];
+  skipped: Array<{ name: string; reason: string }>;
+  errors: Array<{ name: string; error: string }>;
+}
+
+// -------------------------------------------------------------------------------------------------
+// Implementation
+// -------------------------------------------------------------------------------------------------
+
+/**
+ * Load providers from config, instantiate via factory, register into the registry.
+ *
+ * If **any** entry has invalid metadata, the whole load aborts with a `CapabilityError(VALIDATION)`
+ * carrying every error — partial loads would leave the system in an inconsistent state.
+ *
+ * Factory exceptions abort the load as well (the operator needs to fix that before the service
+ * can serve traffic).
+ *
+ * Skipped entries (disabled OR factory returned null) are reported in `result.skipped`.
+ */
+export function loadProvidersFromConfig<TProvider extends ICapabilityProvider>(
+  registry: ProviderRegistry<TProvider>,
+  options: LoaderOptions<TProvider>
+): LoaderResult {
+  const config = readConfig(options);
+  const skipDisabled = options.skipDisabled ?? true;
+
+  // 1. Validate every entry's metadata up-front. Aggregate errors.
+  const validationErrors: Array<{ name: string; errors: string[] }> = [];
+  for (const entry of config.providers) {
+    const result = validateProviderMetadata(asMetadata(entry));
+    if (!result.ok) {
+      validationErrors.push({ name: entry.name ?? "<unnamed>", errors: result.errors });
+    }
+  }
+  if (validationErrors.length > 0) {
+    throw new CapabilityError({
+      code: "CAPABILITY_REGISTRY_LOAD_FAILED",
+      category: ErrorCategory.VALIDATION,
+      message: `Provider config invalid: ${validationErrors.length} entrie(s) rejected`,
+      details: { validationErrors },
+    });
+  }
+
+  // 2. Instantiate via factory and register. Track outcomes.
+  const result: LoaderResult = { registered: [], skipped: [], errors: [] };
+
+  for (const entry of config.providers) {
+    if (skipDisabled && entry.enabled === false) {
+      result.skipped.push({ name: entry.name, reason: "disabled in config" });
+      continue;
+    }
+
+    let instance: TProvider | null;
+    try {
+      instance = options.factory(entry);
+    } catch (e) {
+      result.errors.push({ name: entry.name, error: (e as Error).message });
+      throw new CapabilityError({
+        code: "CAPABILITY_REGISTRY_FACTORY_FAILED",
+        category: ErrorCategory.INTERNAL,
+        message: `Factory threw for provider "${entry.name}": ${(e as Error).message}`,
+        cause: e,
+        details: { name: entry.name },
+      });
+    }
+
+    if (instance === null) {
+      result.skipped.push({ name: entry.name, reason: "factory returned null" });
+      continue;
+    }
+
+    try {
+      registry.register(instance);
+      result.registered.push(entry.name);
+    } catch (e) {
+      result.errors.push({ name: entry.name, error: (e as Error).message });
+      throw e; // registry errors are fatal; rethrow
+    }
+  }
+
+  return result;
+}
+
+// -------------------------------------------------------------------------------------------------
+// Helpers
+// -------------------------------------------------------------------------------------------------
+
+function readConfig<T extends ICapabilityProvider>(
+  options: LoaderOptions<T>
+): ProviderConfigFile {
+  if (options.config) return options.config;
+  if (!options.configPath) {
+    throw new CapabilityError({
+      code: "CAPABILITY_REGISTRY_LOAD_FAILED",
+      category: ErrorCategory.INTERNAL,
+      message: "Either configPath or config must be provided",
+    });
+  }
+  const absolute = resolve(options.configPath);
+  let raw: string;
+  try {
+    raw = readFileSync(absolute, "utf-8");
+  } catch (e) {
+    throw new CapabilityError({
+      code: "CAPABILITY_REGISTRY_LOAD_FAILED",
+      category: ErrorCategory.INTERNAL,
+      message: `Cannot read provider config at ${absolute}: ${(e as Error).message}`,
+      cause: e,
+    });
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (e) {
+    throw new CapabilityError({
+      code: "CAPABILITY_REGISTRY_LOAD_FAILED",
+      category: ErrorCategory.VALIDATION,
+      message: `Provider config at ${absolute} is not valid JSON: ${(e as Error).message}`,
+      cause: e,
+    });
+  }
+  if (
+    typeof parsed !== "object" ||
+    parsed === null ||
+    !Array.isArray((parsed as { providers?: unknown }).providers)
+  ) {
+    throw new CapabilityError({
+      code: "CAPABILITY_REGISTRY_LOAD_FAILED",
+      category: ErrorCategory.VALIDATION,
+      message: `Provider config at ${absolute} must have shape { providers: [...] }`,
+    });
+  }
+  return parsed as ProviderConfigFile;
+}
+
+function asMetadata(entry: ProviderConfigEntry): ProviderMetadata | unknown {
+  // If capability is not a known slug we let validateProviderMetadata surface that error;
+  // otherwise we cast to the known shape.
+  if (!isCapabilitySlug(entry.capability)) {
+    return entry; // validator will reject
+  }
+  return {
+    name: entry.name,
+    capability: entry.capability,
+    supportedChains: entry.supportedChains,
+    version: entry.version,
+    ...(entry.features !== undefined && { features: entry.features }),
+    ...(entry.enabled !== undefined && { enabled: entry.enabled }),
+  } satisfies ProviderMetadata;
+}

--- a/shared/capability/registry.ts
+++ b/shared/capability/registry.ts
@@ -1,0 +1,211 @@
+/**
+ * ProviderRegistry — generic container for capability providers.
+ *
+ * Each backend service instantiates **one** registry per capability it serves:
+ *
+ *     const registry = new ProviderRegistry<ISwapProvider>();
+ *     registry.register(new UniswapSwapAdapter(...));
+ *     registry.register(new ThirdwebSwapAdapter(...));
+ *     registry.register(new AerodromeSwapAdapter(...));
+ *
+ * Then the capability facade asks the registry for ranked candidates:
+ *
+ *     const candidates = registry.listByChain(req.chainId);
+ *     const ranked = policy.rank(candidates, req);
+ *     // ... iterate, call supportsRoute, call the action
+ *
+ * The registry is **not** aware of policy or transport. It only answers structural questions:
+ * "what's registered? what supports this chain? who's healthy?".
+ *
+ * See ADR 002 (capability + provider) and CONVENTIONS.md §7 (imports).
+ */
+
+import { CapabilityError, ErrorCategory } from "./errors";
+import type {
+  CapabilitySlug,
+  ICapabilityProvider,
+  ProviderMetadata,
+} from "./provider.types";
+import { validateProviderMetadata } from "./provider.types";
+import type { ChainId } from "./envelope.types";
+import type {
+  HealthOracle,
+  ListByChainOptions,
+  RegistryEvent,
+  RegistryListener,
+  RegistryListFilter,
+} from "./registry.types";
+
+const ALWAYS_HEALTHY: HealthOracle = { isHealthy: () => true };
+
+export class ProviderRegistry<TProvider extends ICapabilityProvider> {
+  private readonly providers = new Map<string, TProvider>();
+  private readonly listeners = new Set<RegistryListener>();
+  private healthOracle: HealthOracle = ALWAYS_HEALTHY;
+
+  /**
+   * Register a provider. The metadata is validated before insertion; an invalid metadata
+   * throws a `CapabilityError(VALIDATION)`.
+   *
+   * Duplicate names throw — the registry is the single source of truth for provider identity.
+   */
+  register(provider: TProvider): void {
+    const validation = validateProviderMetadata(provider.metadata);
+    if (!validation.ok) {
+      throw new CapabilityError({
+        code: "CAPABILITY_REGISTRY_INVALID_METADATA",
+        category: ErrorCategory.VALIDATION,
+        message: `Cannot register provider "${maybeName(provider)}": metadata invalid`,
+        details: { errors: validation.errors, name: maybeName(provider) },
+      });
+    }
+
+    if (provider.name !== provider.metadata.name) {
+      throw new CapabilityError({
+        code: "CAPABILITY_REGISTRY_NAME_MISMATCH",
+        category: ErrorCategory.VALIDATION,
+        message: `Provider name "${provider.name}" does not match metadata.name "${provider.metadata.name}"`,
+        details: { topLevelName: provider.name, metadataName: provider.metadata.name },
+      });
+    }
+
+    if (this.providers.has(provider.name)) {
+      throw new CapabilityError({
+        code: "CAPABILITY_REGISTRY_DUPLICATE",
+        category: ErrorCategory.VALIDATION,
+        message: `Provider "${provider.name}" is already registered`,
+        details: { name: provider.name },
+      });
+    }
+
+    this.providers.set(provider.name, provider);
+    this.emit({ kind: "registered", provider });
+  }
+
+  /**
+   * Unregister a provider by name. Returns `true` if it existed, `false` otherwise.
+   * Mainly used in tests and in hot-swap scenarios; in production providers come and go via deploys.
+   */
+  unregister(name: string): boolean {
+    const had = this.providers.delete(name);
+    if (had) this.emit({ kind: "unregistered", providerName: name });
+    return had;
+  }
+
+  /**
+   * Lookup by exact name. Returns `undefined` when missing — callers decide how to react.
+   * No alias resolution; that's the policy's job (see `provider-selector.service.ts`).
+   */
+  getByName(name: string): TProvider | undefined {
+    return this.providers.get(name);
+  }
+
+  /**
+   * Total number of registered providers regardless of capability / chain / health.
+   */
+  size(): number {
+    return this.providers.size;
+  }
+
+  /**
+   * List all providers matching the optional filter.
+   *
+   * Defaults:
+   *  - `capability` — no filter
+   *  - `healthy` — no filter (returns healthy and unhealthy alike)
+   *  - `includeDisabled` — false (stubs with `metadata.enabled === false` are excluded)
+   */
+  listAll(filter: RegistryListFilter = {}): TProvider[] {
+    const out: TProvider[] = [];
+    for (const p of this.providers.values()) {
+      if (filter.capability && p.metadata.capability !== filter.capability) continue;
+      if (!filter.includeDisabled && p.metadata.enabled === false) continue;
+      if (filter.healthy !== undefined) {
+        const healthy = this.healthOracle.isHealthy(p.name);
+        if (filter.healthy && !healthy) continue;
+        if (!filter.healthy && healthy) continue;
+      }
+      out.push(p);
+    }
+    return out;
+  }
+
+  /**
+   * Providers that declare support for `chainId`. By default excludes disabled stubs and
+   * unhealthy providers — that's the production default the facades rely on.
+   *
+   * Use `{ healthy: undefined }` to include unhealthy providers (e.g. for diagnostic views).
+   */
+  listByChain(
+    chainId: ChainId,
+    options: ListByChainOptions = {}
+  ): TProvider[] {
+    const includeDisabled = options.includeDisabled ?? false;
+    // Distinguish "key absent" (default = healthy-only) from "key present as undefined"
+    // (caller explicitly asked to skip health filtering). `?? true` would collapse both.
+    const healthyFilter = "healthy" in options ? options.healthy : true;
+    const cap = options.capability;
+
+    const out: TProvider[] = [];
+    for (const p of this.providers.values()) {
+      if (cap && p.metadata.capability !== cap) continue;
+      if (!includeDisabled && p.metadata.enabled === false) continue;
+      if (!p.metadata.supportedChains.includes(chainId)) continue;
+      if (healthyFilter === true && !this.healthOracle.isHealthy(p.name)) continue;
+      if (healthyFilter === false && this.healthOracle.isHealthy(p.name)) continue;
+      out.push(p);
+    }
+    return out;
+  }
+
+  /**
+   * Attach a health oracle (typically `ProviderHealthTracker` from card #209).
+   * Calling this twice replaces the previous oracle.
+   *
+   * When detached (passing `undefined`), the registry reverts to "all healthy" — useful in tests.
+   */
+  attachHealthOracle(oracle: HealthOracle | undefined): void {
+    this.healthOracle = oracle ?? ALWAYS_HEALTHY;
+  }
+
+  /**
+   * Subscribe to registry events. Returns an unsubscribe function.
+   */
+  subscribe(listener: RegistryListener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  /**
+   * Materialise the metadata of every registered provider. Convenient for the discovery
+   * handler (card #207) and for the conformance test helper.
+   */
+  metadataSnapshot(): ProviderMetadata[] {
+    return [...this.providers.values()].map((p) => p.metadata);
+  }
+
+  /**
+   * Clear the registry. Test-only — production code should not call this.
+   */
+  clear(): void {
+    const names = [...this.providers.keys()];
+    this.providers.clear();
+    for (const n of names) this.emit({ kind: "unregistered", providerName: n });
+  }
+
+  private emit(event: RegistryEvent): void {
+    for (const l of this.listeners) {
+      try {
+        l(event);
+      } catch {
+        // Listener errors are isolated — the registry never throws from emit.
+      }
+    }
+  }
+}
+
+function maybeName(p: ICapabilityProvider): string {
+  return typeof p.name === "string" ? p.name : "<unknown>";
+}

--- a/shared/capability/registry.types.ts
+++ b/shared/capability/registry.types.ts
@@ -1,0 +1,56 @@
+/**
+ * Types used by the ProviderRegistry that aren't part of the public envelope/provider API.
+ *
+ * Keeping them in a sibling file so `registry.ts` stays focused on behaviour.
+ */
+
+import type { CapabilitySlug, ICapabilityProvider } from "./provider.types";
+import type { ChainId } from "./envelope.types";
+
+/**
+ * Filter passed to `registry.listAll`.
+ *
+ * - `capability` — only return providers for this slug.
+ * - `healthy` — when `true`, exclude providers that have been marked unhealthy.
+ *   When `undefined`, returns every registered provider regardless of health.
+ *   When `false`, returns only the unhealthy ones (useful for monitoring views).
+ * - `includeDisabled` — when `true`, include providers with `metadata.enabled === false`
+ *   (stubs). Default: `false`.
+ */
+export interface RegistryListFilter {
+  capability?: CapabilitySlug;
+  healthy?: boolean;
+  includeDisabled?: boolean;
+}
+
+/**
+ * The health view a Registry consults when filtering. The full implementation lives in
+ * `health.ts` (card #209); this is the narrow contract the registry depends on so the two
+ * modules can be tested independently.
+ */
+export interface HealthOracle {
+  isHealthy(providerName: string): boolean;
+}
+
+/**
+ * Registry events surfaced to subscribers (currently used by the conformance helper and the
+ * health tracker integration). Lightweight; do not abuse with high-frequency events.
+ */
+export type RegistryEvent =
+  | { kind: "registered"; provider: ICapabilityProvider }
+  | { kind: "unregistered"; providerName: string };
+
+export type RegistryListener = (event: RegistryEvent) => void;
+
+/**
+ * A shorthand for "all providers in this registry that match a chain".
+ *
+ * The registry guarantees `result.every(p => p.metadata.supportedChains.includes(chainId))`.
+ */
+export interface ListByChainOptions {
+  capability?: CapabilitySlug;
+  healthy?: boolean;
+  includeDisabled?: boolean;
+}
+
+export type { CapabilitySlug, ICapabilityProvider, ChainId };


### PR DESCRIPTION
> **Stacked PR** — depends on #277 (Bloco 2). When that merges into develop, GitHub will retarget this PR to develop automatically.

## Cards

- Closes Panorama-Block/panoramablock-backend#204 — Generalize swap provider registry module
- Closes Panorama-Block/panoramablock-backend#205 — Implement provider registry config loader
- Closes Panorama-Block/panoramablock-backend#206 — Generalize provider priority policy
- Closes Panorama-Block/panoramablock-backend#207 — Implement provider capability discovery endpoint
- Closes Panorama-Block/panoramablock-backend#208 — Add provider limitations model
- Closes Panorama-Block/panoramablock-backend#209 — Add provider health status abstraction
- Closes Panorama-Block/panoramablock-backend#210 — Generalize provider registry tests

## Mudanças

Camada 0 runtime — o substrato que cada capability facade vai consumir.

### Arquivos novos em `backend/shared/capability/`

| Card | Arquivo | O que faz |
|---|---|---|
| #204 | `registry.ts` + `registry.types.ts` | `ProviderRegistry<T>` genérico: `register`, `getByName`, `listAll`, `listByChain`, health oracle plug, events, snapshot |
| #205 | `registry.loader.ts` | `loadProvidersFromConfig`: lê JSON, valida via `validateProviderMetadata`, instancia via factory service-supplied, aborta em erro |
| #206 | `policy.ts` + `policies/chain-asset-priority.policy.ts` | `IPriorityPolicy` + `ChainAssetPriorityPolicy` (per-chain, optional per-asset, cross-chain default key) + `fallbackInvoke` helper |
| #207 | `http/discovery.handler.ts` | `createDiscoveryHandler` factory: cache 30s, force-refresh, retorna `CapabilitySuccessResponse<AvailabilityMap>` |
| #208 | `provider-limitations.ts` | `ProviderLimitations` + `applyLimitations` + `compareDecimalStrings` (wei-safe sem BigInt) |
| #209 | `health.ts` | `ProviderHealthTracker` implementa `HealthOracle`, polling com scheduler injetável, N falhas consecutivas → unhealthy |
| #210 | `__tests__/registry.conformance.ts` | `describeRegistryConformance` helper exportado pro pacote; self-test exercita ele in-package |

### Substituições futuras (não neste PR)

- Hardcoded `BASE_CHAIN_ID = 8453` + if/else priority em `liquid-swap-service/src/application/services/provider-selector.service.ts:8,179-196` → será removido pelo Rizzi nos cards #230, #231 consumindo `ChainAssetPriorityPolicy` daqui.
- Manual map em `liquid-swap-service/src/infrastructure/di/container.ts` → substituído por `ProviderRegistry` + `loadProvidersFromConfig` no card #230.

## Tests

```
176/176 passing
typecheck: clean
```

- 22 registry tests, 18 policy + fallbackInvoke tests, 17 limitations, 15 health, 11 loader, 10 discovery handler
- 15 conformance assertions executadas via `registry.conformance.self.test.ts` (validação do próprio helper)
- 68 tests do Bloco 2 (envelope, errors, provider, availability) — todos continuam verdes

## Camada / DoD

- [x] Testes locais passando (176/176)
- [x] Typecheck clean
- [x] Sem mudanças fora de `shared/capability/`
- [x] Backward-compat preservada (pacote novo, nada substituído ainda)
- [x] Doc inline em cada módulo + helper de conformance documentado
- [ ] Review approved por par (Coletto primário, Rizzi secundário)

## Notas pra review

- **PR stacked**: o base é `feat/hugo-capability-bloco-2`, não `develop`. Quando #277 mergear, GitHub retarget automático.
- `listByChain` distingue `'healthy' in options ? options.healthy : true` (key absent = healthy-only; key present + `undefined` = no filter; explicit `false` = só unhealthy). Tem teste cobrindo.
- `fallbackInvoke` por default **rethrow** em `VALIDATION` e `UNSUPPORTED_ROUTE` (faz fallback nas outras categorias). Cabe `shouldFallback` custom se a capability quiser política diferente.
- `applyLimitations` retorna `Result` tagged em vez de jogar — facilita uso em middleware que agrega violações de múltiplos checks.
- `ProviderHealthTracker.start()` faz `setInterval(...).unref()` por default — não bloqueia shutdown.
- `discovery.handler` é **síncrono**: o build do `AvailabilityMap` é pure CPU, o polling roda fora de banda no tracker.