### PR TITLE
[#211–#214] Chain Onboarding — manifests Base, Avalanche, Ethereum (Bloco 4)

### DIFF
--- a/shared/capability/chains/__tests__/chain.types.test.ts
+++ b/shared/capability/chains/__tests__/chain.types.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  loadChains,
+  getChain,
+  tryGetChain,
+  listChains,
+  listKnownChains,
+  validateChainManifest,
+  _resetChainsCache,
+  type ChainManifest,
+} from "../chain.types";
+import { CapabilityError } from "../../errors";
+
+function manifest(input: Partial<ChainManifest> & Pick<ChainManifest, "id" | "slug">): ChainManifest {
+  return {
+    id: input.id,
+    slug: input.slug,
+    name: input.name ?? input.slug,
+    nativeAsset: input.nativeAsset ?? { symbol: "ETH", decimals: 18 },
+    rpcDefaults: input.rpcDefaults ?? ["https://example.com/rpc"],
+    blockExplorerUrl: input.blockExplorerUrl ?? "https://example.com",
+    capabilitiesSupported: input.capabilitiesSupported ?? ["swap"],
+  };
+}
+
+beforeEach(() => {
+  _resetChainsCache();
+});
+
+describe("validateChainManifest", () => {
+  it("accepts a complete valid manifest", () => {
+    expect(validateChainManifest(manifest({ id: 1, slug: "ethereum" })).ok).toBe(true);
+  });
+
+  it("rejects non-object input", () => {
+    expect(validateChainManifest(null).ok).toBe(false);
+    expect(validateChainManifest("manifest").ok).toBe(false);
+  });
+
+  it("rejects invalid id (zero, negative, non-integer, missing)", () => {
+    const base = manifest({ id: 1, slug: "x" });
+    expect(validateChainManifest({ ...base, id: 0 }).ok).toBe(false);
+    expect(validateChainManifest({ ...base, id: -1 }).ok).toBe(false);
+    expect(validateChainManifest({ ...base, id: 1.5 }).ok).toBe(false);
+    const { id: _id, ...withoutId } = base;
+    expect(validateChainManifest(withoutId).ok).toBe(false);
+  });
+
+  it("rejects invalid slug (uppercase, starts with digit, underscores)", () => {
+    expect(validateChainManifest(manifest({ id: 1, slug: "Base" })).ok).toBe(false);
+    expect(validateChainManifest(manifest({ id: 1, slug: "1eth" })).ok).toBe(false);
+    expect(validateChainManifest(manifest({ id: 1, slug: "my_chain" })).ok).toBe(false);
+  });
+
+  it("rejects bad nativeAsset", () => {
+    expect(
+      validateChainManifest({ ...manifest({ id: 1, slug: "x" }), nativeAsset: null }).ok
+    ).toBe(false);
+    expect(
+      validateChainManifest({
+        ...manifest({ id: 1, slug: "x" }),
+        nativeAsset: { symbol: "", decimals: 18 },
+      }).ok
+    ).toBe(false);
+    expect(
+      validateChainManifest({
+        ...manifest({ id: 1, slug: "x" }),
+        nativeAsset: { symbol: "ETH", decimals: -1 },
+      }).ok
+    ).toBe(false);
+  });
+
+  it("rejects empty rpcDefaults or non-http(s) entries", () => {
+    expect(
+      validateChainManifest(manifest({ id: 1, slug: "x", rpcDefaults: [] })).ok
+    ).toBe(false);
+    expect(
+      validateChainManifest(
+        manifest({ id: 1, slug: "x", rpcDefaults: ["ftp://no.scheme/"] })
+      ).ok
+    ).toBe(false);
+    expect(
+      validateChainManifest(
+        manifest({ id: 1, slug: "x", rpcDefaults: ["wss://websocket.example/"] })
+      ).ok
+    ).toBe(false);
+  });
+
+  it("rejects invalid blockExplorerUrl", () => {
+    expect(
+      validateChainManifest(manifest({ id: 1, slug: "x", blockExplorerUrl: "not-a-url" })).ok
+    ).toBe(false);
+  });
+
+  it("rejects unknown capability slug", () => {
+    expect(
+      validateChainManifest({
+        ...manifest({ id: 1, slug: "x" }),
+        capabilitiesSupported: ["derivatives" as unknown as "swap"],
+      }).ok
+    ).toBe(false);
+  });
+
+  it("rejects duplicate capabilities", () => {
+    expect(
+      validateChainManifest(
+        manifest({ id: 1, slug: "x", capabilitiesSupported: ["swap", "swap"] })
+      ).ok
+    ).toBe(false);
+  });
+
+  it("collects multiple errors at once", () => {
+    const r = validateChainManifest({
+      id: 0,
+      slug: "BAD",
+      name: "",
+      nativeAsset: null,
+      rpcDefaults: [],
+      blockExplorerUrl: "x",
+      capabilitiesSupported: ["unknown"],
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.errors.length).toBeGreaterThanOrEqual(5);
+  });
+});
+
+describe("loadChains — from injected manifests", () => {
+  it("returns the manifests and caches them", () => {
+    const m = [manifest({ id: 1, slug: "ethereum" }), manifest({ id: 8453, slug: "base" })];
+    const result = loadChains({ manifests: m });
+    expect(result).toEqual(m);
+    expect(listChains()).toEqual(m);
+  });
+
+  it("throws aggregating every invalid manifest", () => {
+    const bad: ChainManifest[] = [
+      manifest({ id: 0, slug: "BAD" }), // invalid id + slug
+      manifest({ id: 1, slug: "ok" }),
+      { id: 2, slug: "x" } as unknown as ChainManifest, // missing required fields
+    ];
+    expect(() => loadChains({ manifests: bad })).toThrowError(CapabilityError);
+    try {
+      loadChains({ manifests: bad });
+    } catch (e) {
+      const err = e as CapabilityError;
+      expect(err.code).toBe("CAPABILITY_CHAIN_LOAD_FAILED");
+      expect(Array.isArray((err.details as { errors: unknown[] }).errors)).toBe(true);
+    }
+  });
+
+  it("throws on duplicate id", () => {
+    try {
+      loadChains({
+        manifests: [
+          manifest({ id: 1, slug: "ethereum" }),
+          manifest({ id: 1, slug: "ethereum-classic" }),
+        ],
+      });
+      throw new Error("should have thrown");
+    } catch (e) {
+      expect((e as CapabilityError).code).toBe("CAPABILITY_CHAIN_DUPLICATE_ID");
+    }
+  });
+
+  it("throws on duplicate slug", () => {
+    try {
+      loadChains({
+        manifests: [
+          manifest({ id: 1, slug: "ethereum" }),
+          manifest({ id: 999, slug: "ethereum" }),
+        ],
+      });
+      throw new Error("should have thrown");
+    } catch (e) {
+      expect((e as CapabilityError).code).toBe("CAPABILITY_CHAIN_DUPLICATE_SLUG");
+    }
+  });
+});
+
+describe("getChain / tryGetChain / listKnownChains", () => {
+  beforeEach(() => {
+    loadChains({
+      manifests: [
+        manifest({ id: 1, slug: "ethereum", name: "Ethereum" }),
+        manifest({ id: 8453, slug: "base", name: "Base" }),
+      ],
+    });
+  });
+
+  it("looks up by id", () => {
+    expect(getChain(1).slug).toBe("ethereum");
+    expect(getChain(8453).slug).toBe("base");
+  });
+
+  it("looks up by slug", () => {
+    expect(getChain("ethereum").id).toBe(1);
+    expect(getChain("base").id).toBe(8453);
+  });
+
+  it("throws on unknown lookup with informative message", () => {
+    expect(() => getChain(137)).toThrowError(/Unknown chain/);
+    try {
+      getChain("solana");
+    } catch (e) {
+      const err = e as CapabilityError;
+      expect(err.code).toBe("CAPABILITY_CHAIN_UNKNOWN");
+      expect(err.message).toContain("ethereum(1)");
+      expect(err.message).toContain("base(8453)");
+    }
+  });
+
+  it("tryGetChain returns undefined for unknown", () => {
+    expect(tryGetChain(137)).toBeUndefined();
+    expect(tryGetChain("solana")).toBeUndefined();
+  });
+
+  it("listKnownChains returns slug(id) strings", () => {
+    expect(listKnownChains().sort()).toEqual(["base(8453)", "ethereum(1)"]);
+  });
+});
+
+describe("loadChains — from a real directory", () => {
+  it("reads *.manifest.json files (sorted), parses, validates", () => {
+    const dir = mkdtempSync(join(tmpdir(), "chain-load-"));
+    writeFileSync(
+      join(dir, "base.manifest.json"),
+      JSON.stringify(manifest({ id: 8453, slug: "base", name: "Base" })),
+      "utf-8"
+    );
+    writeFileSync(
+      join(dir, "ethereum.manifest.json"),
+      JSON.stringify(manifest({ id: 1, slug: "ethereum", name: "Ethereum" })),
+      "utf-8"
+    );
+    // Non-manifest files are ignored.
+    writeFileSync(join(dir, "README.md"), "ignore me", "utf-8");
+
+    const chains = loadChains({ directory: dir, reload: true });
+    expect(chains.map((c) => c.slug).sort()).toEqual(["base", "ethereum"]);
+  });
+
+  it("throws when directory missing", () => {
+    expect(() =>
+      loadChains({ directory: "/nonexistent/dir", reload: true })
+    ).toThrowError(/Chains directory not found/);
+  });
+
+  it("throws when JSON is malformed", () => {
+    const dir = mkdtempSync(join(tmpdir(), "chain-load-"));
+    writeFileSync(join(dir, "bad.manifest.json"), "{not json", "utf-8");
+    expect(() => loadChains({ directory: dir, reload: true })).toThrowError(
+      /not valid JSON/
+    );
+  });
+});
+
+describe("loadChains — auto-load default directory", () => {
+  it("loads the three committed manifests (base, avalanche, ethereum)", () => {
+    // Default directory is the chains/ dir of this package — should contain the manifests
+    // we ship as part of cards #212-#214.
+    _resetChainsCache();
+    const chains = loadChains();
+    const slugs = chains.map((c) => c.slug).sort();
+    expect(slugs).toEqual(["avalanche", "base", "ethereum"]);
+
+    expect(getChain("base").id).toBe(8453);
+    expect(getChain("avalanche").id).toBe(43114);
+    expect(getChain("ethereum").id).toBe(1);
+  });
+
+  it("Base manifest declares swap, lending, liquidity", () => {
+    _resetChainsCache();
+    const base = getChain("base");
+    expect(new Set(base.capabilitiesSupported)).toEqual(new Set(["swap", "lending", "liquidity"]));
+  });
+
+  it("Avalanche manifest declares swap, lending, liquidity, staking", () => {
+    _resetChainsCache();
+    const av = getChain("avalanche");
+    expect(new Set(av.capabilitiesSupported)).toEqual(
+      new Set(["swap", "lending", "liquidity", "staking"])
+    );
+  });
+
+  it("Ethereum manifest declares swap, staking", () => {
+    _resetChainsCache();
+    const eth = getChain("ethereum");
+    expect(new Set(eth.capabilitiesSupported)).toEqual(new Set(["swap", "staking"]));
+  });
+});

--- a/shared/capability/chains/avalanche.manifest.json
+++ b/shared/capability/chains/avalanche.manifest.json
@@ -1,0 +1,16 @@
+{
+  "id": 43114,
+  "slug": "avalanche",
+  "name": "Avalanche",
+  "nativeAsset": {
+    "symbol": "AVAX",
+    "decimals": 18
+  },
+  "rpcDefaults": [
+    "https://api.avax.network/ext/bc/C/rpc",
+    "https://avalanche.publicnode.com",
+    "https://avalanche-c-chain-rpc.publicnode.com"
+  ],
+  "blockExplorerUrl": "https://snowtrace.io",
+  "capabilitiesSupported": ["swap", "lending", "liquidity", "staking"]
+}

--- a/shared/capability/chains/base.manifest.json
+++ b/shared/capability/chains/base.manifest.json
@@ -1,0 +1,16 @@
+{
+  "id": 8453,
+  "slug": "base",
+  "name": "Base",
+  "nativeAsset": {
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "rpcDefaults": [
+    "https://mainnet.base.org",
+    "https://base.publicnode.com",
+    "https://base-rpc.publicnode.com"
+  ],
+  "blockExplorerUrl": "https://basescan.org",
+  "capabilitiesSupported": ["swap", "lending", "liquidity"]
+}

--- a/shared/capability/chains/chain.types.ts
+++ b/shared/capability/chains/chain.types.ts
@@ -1,0 +1,319 @@
+/**
+ * Chain manifest — first-class entity for supported chains.
+ *
+ * Every supported chain is described by a JSON file in this directory. Consumers go through
+ * `getChain(idOrSlug)` rather than using literal chain ids — see ADR 005.
+ *
+ * Cards #211–#214 (SPRINT_HUGO.md).
+ */
+
+import { readdirSync, readFileSync, existsSync, statSync } from "node:fs";
+import { extname, join, resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { CapabilityError, ErrorCategory } from "../errors";
+import type { CapabilitySlug } from "../provider.types";
+import { isCapabilitySlug } from "../provider.types";
+
+// -------------------------------------------------------------------------------------------------
+// The manifest shape
+// -------------------------------------------------------------------------------------------------
+
+export interface ChainNativeAsset {
+  symbol: string;
+  decimals: number;
+}
+
+export interface ChainManifest {
+  id: number;
+  /** kebab-case canonical id (e.g. 'base', 'avalanche', 'ethereum'). */
+  slug: string;
+  /** Display name (e.g. 'Base', 'Avalanche', 'Ethereum'). */
+  name: string;
+  nativeAsset: ChainNativeAsset;
+  /** Public RPC defaults — never put API keys here. */
+  rpcDefaults: string[];
+  blockExplorerUrl: string;
+  capabilitiesSupported: CapabilitySlug[];
+}
+
+// -------------------------------------------------------------------------------------------------
+// Loading + lookup
+// -------------------------------------------------------------------------------------------------
+
+export interface LoadChainsOptions {
+  /** Where to look for `*.manifest.json` files. Defaults to this `chains/` directory. */
+  directory?: string;
+  /** Inject manifests directly (skip filesystem). Wins over `directory`. */
+  manifests?: ChainManifest[];
+}
+
+let cached: ChainManifest[] | null = null;
+let cachedById = new Map<number, ChainManifest>();
+let cachedBySlug = new Map<string, ChainManifest>();
+
+/**
+ * Resolve the default chains directory (where `*.manifest.json` files live).
+ *
+ * Works under tsx/ts-node (no compile step) by using `__dirname` when available (CJS) or
+ * `import.meta.url` derivation when running as ESM. Falls back to the source dir.
+ */
+function defaultChainsDir(): string {
+  // CJS path (vitest + ts-jest default).
+  if (typeof __dirname !== "undefined") return __dirname;
+  // ESM fallback: derive from this module URL.
+  // Guarded behind try/catch because `import.meta` is a syntax error in some CJS contexts.
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const url = (Function("return import.meta.url") as () => string)();
+    return dirname(fileURLToPath(url));
+  } catch {
+    return resolve(process.cwd(), "shared/capability/chains");
+  }
+}
+
+/**
+ * Load chain manifests from disk (or from `manifests` if provided) and populate the lookup caches.
+ * Idempotent — calling twice with the same source returns the same array. Pass `{ reload: true }`
+ * to force a re-read (test convenience; production calls this once at boot).
+ *
+ * Throws `CapabilityError(VALIDATION)` aggregating every malformed manifest.
+ */
+export function loadChains(
+  options: LoadChainsOptions & { reload?: boolean } = {}
+): ChainManifest[] {
+  if (cached && !options.reload && !options.manifests && !options.directory) {
+    return cached;
+  }
+
+  const raw: RawManifest[] = options.manifests
+    ? options.manifests.map((m, i) => ({ source: `injected[${i}]`, manifest: m }))
+    : readManifestsFromDir(options.directory ?? defaultChainsDir());
+  const errors: Array<{ source: string; errors: string[] }> = [];
+  const valid: ChainManifest[] = [];
+
+  for (const entry of raw) {
+    const result = validateChainManifest(entry.manifest);
+    if (!result.ok) {
+      errors.push({ source: entry.source, errors: result.errors });
+      continue;
+    }
+    valid.push(entry.manifest as ChainManifest);
+  }
+
+  if (errors.length > 0) {
+    throw new CapabilityError({
+      code: "CAPABILITY_CHAIN_LOAD_FAILED",
+      category: ErrorCategory.VALIDATION,
+      message: `Chain manifest load failed: ${errors.length} invalid file(s)`,
+      details: { errors },
+    });
+  }
+
+  // Reject duplicate ids or slugs across files.
+  const seenIds = new Set<number>();
+  const seenSlugs = new Set<string>();
+  for (const m of valid) {
+    if (seenIds.has(m.id)) {
+      throw new CapabilityError({
+        code: "CAPABILITY_CHAIN_DUPLICATE_ID",
+        category: ErrorCategory.VALIDATION,
+        message: `Duplicate chain id ${m.id} across manifests`,
+        details: { id: m.id },
+      });
+    }
+    if (seenSlugs.has(m.slug)) {
+      throw new CapabilityError({
+        code: "CAPABILITY_CHAIN_DUPLICATE_SLUG",
+        category: ErrorCategory.VALIDATION,
+        message: `Duplicate chain slug "${m.slug}" across manifests`,
+        details: { slug: m.slug },
+      });
+    }
+    seenIds.add(m.id);
+    seenSlugs.add(m.slug);
+  }
+
+  cached = valid;
+  cachedById = new Map(valid.map((m) => [m.id, m]));
+  cachedBySlug = new Map(valid.map((m) => [m.slug, m]));
+  return valid;
+}
+
+/**
+ * Lookup a chain by id (number) or slug (string). Throws `CapabilityError(VALIDATION)` if
+ * the chain isn't loaded — never return undefined silently, since most call sites would
+ * NPE shortly after.
+ *
+ * Auto-loads from the default directory on first call.
+ */
+export function getChain(idOrSlug: number | string): ChainManifest {
+  if (!cached) loadChains();
+  const found =
+    typeof idOrSlug === "number"
+      ? cachedById.get(idOrSlug)
+      : cachedBySlug.get(idOrSlug);
+  if (!found) {
+    throw new CapabilityError({
+      code: "CAPABILITY_CHAIN_UNKNOWN",
+      category: ErrorCategory.VALIDATION,
+      message: `Unknown chain ${JSON.stringify(idOrSlug)}. Known: ${listKnownChains().join(", ")}`,
+      details: { lookup: idOrSlug, known: listKnownChains() },
+    });
+  }
+  return found;
+}
+
+/**
+ * Same as `getChain` but returns `undefined` when missing. Use when the caller already plans for
+ * "chain not configured" as a valid branch (e.g. policy fallback).
+ */
+export function tryGetChain(idOrSlug: number | string): ChainManifest | undefined {
+  if (!cached) loadChains();
+  return typeof idOrSlug === "number"
+    ? cachedById.get(idOrSlug)
+    : cachedBySlug.get(idOrSlug);
+}
+
+/**
+ * All loaded chains. Auto-loads on first call.
+ */
+export function listChains(): ChainManifest[] {
+  if (!cached) loadChains();
+  return cached!;
+}
+
+/**
+ * Human-readable list of `<slug>(<id>)` for error messages.
+ */
+export function listKnownChains(): string[] {
+  if (!cached) loadChains();
+  return cached!.map((m) => `${m.slug}(${m.id})`);
+}
+
+/**
+ * Test convenience — clear the lazy cache and lookups.
+ */
+export function _resetChainsCache(): void {
+  cached = null;
+  cachedById = new Map();
+  cachedBySlug = new Map();
+}
+
+// -------------------------------------------------------------------------------------------------
+// Validation
+// -------------------------------------------------------------------------------------------------
+
+interface ValidationOk {
+  ok: true;
+}
+interface ValidationErr {
+  ok: false;
+  errors: string[];
+}
+type ValidationResult = ValidationOk | ValidationErr;
+
+export function validateChainManifest(m: unknown): ValidationResult {
+  const errors: string[] = [];
+  if (typeof m !== "object" || m === null) {
+    return { ok: false, errors: ["manifest must be an object"] };
+  }
+  const x = m as Partial<ChainManifest>;
+
+  if (!Number.isInteger(x.id) || (x.id as number) <= 0) {
+    errors.push(`id must be a positive integer (got ${JSON.stringify(x.id)})`);
+  }
+
+  if (typeof x.slug !== "string" || !/^[a-z][a-z0-9-]*$/.test(x.slug)) {
+    errors.push(
+      `slug must be lowercase kebab-case starting with letter (got ${JSON.stringify(x.slug)})`
+    );
+  }
+
+  if (typeof x.name !== "string" || x.name.length === 0) {
+    errors.push("name must be a non-empty string");
+  }
+
+  if (
+    typeof x.nativeAsset !== "object" ||
+    x.nativeAsset === null ||
+    typeof x.nativeAsset.symbol !== "string" ||
+    x.nativeAsset.symbol.length === 0 ||
+    !Number.isInteger(x.nativeAsset.decimals) ||
+    (x.nativeAsset.decimals as number) < 0
+  ) {
+    errors.push("nativeAsset must be { symbol: non-empty string, decimals: non-negative integer }");
+  }
+
+  if (
+    !Array.isArray(x.rpcDefaults) ||
+    x.rpcDefaults.length === 0 ||
+    x.rpcDefaults.some((r) => typeof r !== "string" || !/^https?:\/\//.test(r as string))
+  ) {
+    errors.push(
+      "rpcDefaults must be a non-empty array of http(s) URLs (no API keys in defaults)"
+    );
+  }
+
+  if (typeof x.blockExplorerUrl !== "string" || !/^https?:\/\//.test(x.blockExplorerUrl)) {
+    errors.push("blockExplorerUrl must be a valid http(s) URL");
+  }
+
+  if (
+    !Array.isArray(x.capabilitiesSupported) ||
+    x.capabilitiesSupported.some((c) => !isCapabilitySlug(c))
+  ) {
+    errors.push("capabilitiesSupported must be an array of known CapabilitySlug values");
+  } else if (new Set(x.capabilitiesSupported).size !== x.capabilitiesSupported.length) {
+    errors.push("capabilitiesSupported must not contain duplicates");
+  }
+
+  return errors.length === 0 ? { ok: true } : { ok: false, errors };
+}
+
+// -------------------------------------------------------------------------------------------------
+// FS helpers
+// -------------------------------------------------------------------------------------------------
+
+interface RawManifest {
+  source: string;
+  manifest: unknown;
+}
+
+function readManifestsFromDir(dir: string): RawManifest[] {
+  if (!existsSync(dir) || !statSync(dir).isDirectory()) {
+    throw new CapabilityError({
+      code: "CAPABILITY_CHAIN_LOAD_FAILED",
+      category: ErrorCategory.INTERNAL,
+      message: `Chains directory not found: ${dir}`,
+    });
+  }
+  const files = readdirSync(dir)
+    .filter((f) => f.endsWith(".manifest.json") && extname(f) === ".json")
+    .map((f) => join(dir, f))
+    .sort();
+  return files.map((path) => {
+    let raw: string;
+    try {
+      raw = readFileSync(path, "utf-8");
+    } catch (e) {
+      throw new CapabilityError({
+        code: "CAPABILITY_CHAIN_LOAD_FAILED",
+        category: ErrorCategory.INTERNAL,
+        message: `Cannot read manifest ${path}: ${(e as Error).message}`,
+        cause: e,
+      });
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch (e) {
+      throw new CapabilityError({
+        code: "CAPABILITY_CHAIN_LOAD_FAILED",
+        category: ErrorCategory.VALIDATION,
+        message: `Manifest ${path} is not valid JSON: ${(e as Error).message}`,
+      });
+    }
+    return { source: path, manifest: parsed };
+  });
+}

--- a/shared/capability/chains/ethereum.manifest.json
+++ b/shared/capability/chains/ethereum.manifest.json
@@ -1,0 +1,16 @@
+{
+  "id": 1,
+  "slug": "ethereum",
+  "name": "Ethereum",
+  "nativeAsset": {
+    "symbol": "ETH",
+    "decimals": 18
+  },
+  "rpcDefaults": [
+    "https://ethereum-rpc.publicnode.com",
+    "https://eth.llamarpc.com",
+    "https://rpc.ankr.com/eth"
+  ],
+  "blockExplorerUrl": "https://etherscan.io",
+  "capabilitiesSupported": ["swap", "staking"]
+}

--- a/shared/capability/chains/index.ts
+++ b/shared/capability/chains/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Public re-exports for the chains sub-module.
+ *
+ * Consumers import from `@panorama/capability/chains` for chain manifests + lookup helpers.
+ * The chains module is independent from the registry — it just describes which networks the
+ * system knows about and what capabilities each chain claims to support.
+ */
+
+export {
+  loadChains,
+  getChain,
+  tryGetChain,
+  listChains,
+  listKnownChains,
+  validateChainManifest,
+  _resetChainsCache,
+  type ChainManifest,
+  type ChainNativeAsset,
+  type LoadChainsOptions,
+} from "./chain.types";

--- a/shared/capability/index.ts
+++ b/shared/capability/index.ts
@@ -112,3 +112,16 @@ export {
   type DiscoveryHandlerInput,
   type DiscoveryHandlerOutput,
 } from "./http/discovery.handler";
+
+// Chain manifests — single source of truth for supported chains.
+export {
+  loadChains,
+  getChain,
+  tryGetChain,
+  listChains,
+  listKnownChains,
+  validateChainManifest,
+  type ChainManifest,
+  type ChainNativeAsset,
+  type LoadChainsOptions,
+} from "./chains";


### PR DESCRIPTION
> **Stacked PR** — depends on #278 (Bloco 3) → #277 (Bloco 2). Will retarget to develop as the chain mergea.

## Cards

- Closes Panorama-Block/panoramablock-backend#211 — Generalize chain runtime config into manifest schema
- Closes Panorama-Block/panoramablock-backend#212 — Generalize Base chain registration
- Closes Panorama-Block/panoramablock-backend#213 — Generalize Avalanche chain registration
- Closes Panorama-Block/panoramablock-backend#214 — Generalize Ethereum chain registration

## Mudanças

Implementa ADR 005 (chain onboarding model). Cada chain vira um manifest JSON em `backend/shared/capability/chains/` e consumidores trocam `8453` por `getChain('base').id`.

### Arquivos novos

| Card | Arquivo | O que faz |
|---|---|---|
| #211 | `chains/chain.types.ts` + `chains/index.ts` | `ChainManifest` shape, `validateChainManifest` (estruturado), `loadChains` (lazy + cacheable, auto-discover via dir OU manifests injetados), `getChain`/`tryGetChain` (id OR slug), `listChains`, `listKnownChains`, `_resetChainsCache` (test only) |
| #212 | `chains/base.manifest.json` | id 8453, native ETH, capabilities `[swap, lending, liquidity]` |
| #213 | `chains/avalanche.manifest.json` | id 43114, native AVAX, capabilities `[swap, lending, liquidity, staking]` |
| #214 | `chains/ethereum.manifest.json` | id 1, native ETH, capabilities `[swap, staking]` |

### Guarantees

- Rejeita ids duplicados, slugs duplicados, RPC URLs não-http(s), `CapabilitySlug` desconhecido
- Agrega todos os erros de manifest num único `CapabilityError(VALIDATION)` no boot — sem partial loads
- RPC defaults só com URLs públicas (sem API keys)
- Capabilities declaradas honestamente — `staking` não está em Base ainda (stub via card #248 vai adicionar quando cbETH for implementado)

## Tests

```
202/202 passing (26 chain-specific + 176 dos blocos 2/3)
typecheck: clean
```

26 chain tests cobrem: validação shape-por-shape, loader inject + filesystem, duplicate detection, JSON malformado, dir missing, auto-load dos 3 manifests reais committed.

## Consumo futuro

Subsequent cards trocarão chainId literals por manifest lookups:

- Rizzi #231 — remove `BASE_CHAIN_ID = 8453` de `liquid-swap-service/src/application/services/provider-selector.service.ts:8`
- Hugo #247 — `LidoProviderAdapter` declara `metadata.supportedChains = [getChain('ethereum').id]`
- Hugo #82 — deploy scripts referem `getChain('base')` para RPC + explorer URLs

## Camada / DoD

- [x] Testes locais passando (202/202)
- [x] Typecheck clean
- [x] Sem mudanças fora de `shared/capability/`
- [x] Backward-compat preservada (módulo novo)
- [x] Doc inline em cada export + ADR 005 já mergeada no PR exec-layer#90
- [ ] Review approved por par (Coletto primário, Rizzi secundário)

## Notas pra review

- **PR stacked**: base = `feat/hugo-capability-bloco-3`. Mergeia depois de #278 e #277.
- `validateChainManifest` retorna `Result` tagged (mesmo padrão de `validateProviderMetadata` no Bloco 2) pra permitir agregar violações.
- `loadChains` é **lazy** — não dispara IO no import. Primeira chamada de `getChain` triggers o load.
- `defaultChainsDir()` tenta `__dirname` (CJS) e cai pra `import.meta.url` (ESM), com último fallback pra `process.cwd()/shared/capability/chains` — robusto contra os 3 modos de execução (vitest, tsx, dist).
- Self-test no fim do `chain.types.test.ts` consome os 3 manifests reais (`getChain('base').id === 8453` etc.) — falha CI se algum manifest sair do shape ou desaparecer.