### PR TITLE
[#244–#249] Staking Capability — first capability migration (Bloco 5)

### DIFF
--- a/lido-service/src/__tests__/staking.conformance.test.ts
+++ b/lido-service/src/__tests__/staking.conformance.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Staking capability conformance — exercises the shared
+ * `describeRegistryConformance` helper from `@panorama/capability` against an in-process
+ * staking-shaped fake.
+ *
+ * The Lido + Base stub run inside the same registry in production via `buildStakingContainer`;
+ * here we use lightweight fakes so the suite runs offline and fast. The adapter integration
+ * test (forked mainnet) is a separate file (`lido.provider.adapter.integration.test.ts`,
+ * shipped in a follow-up PR per the project rule: adapter tests fork mainnet, never mocks).
+ *
+ * Card #249 (SPRINT_HUGO.md).
+ */
+
+import { ProviderRegistry } from '@panorama/capability';
+import { describeRegistryConformance } from '@panorama/capability/__tests__/registry.conformance';
+
+import type { IStakingProvider } from '../domain/ports/staking.provider.port';
+
+function fakeStaking(input: {
+  name: string;
+  chains: number[];
+  enabled?: boolean;
+}): IStakingProvider {
+  return {
+    name: input.name,
+    metadata: {
+      name: input.name,
+      capability: 'staking',
+      supportedChains: input.chains,
+      version: '1.0.0',
+      ...(input.enabled !== undefined && { enabled: input.enabled }),
+    },
+    async supportsRoute({ chainId }) {
+      return input.chains.includes(chainId);
+    },
+    async getPosition() {
+      return null;
+    },
+    async prepareStake() {
+      return [];
+    },
+    async prepareUnstake() {
+      return [];
+    },
+    async prepareClaim() {
+      return [];
+    },
+    async getApr() {
+      return null;
+    },
+  } satisfies IStakingProvider;
+}
+
+describeRegistryConformance('staking', () => ({
+  registry: new ProviderRegistry<IStakingProvider>(),
+  providers: {
+    chainA: fakeStaking({ name: 'lido-fake', chains: [1] }),
+    chainB: fakeStaking({ name: 'base-fake', chains: [8453] }),
+    stub: fakeStaking({ name: 'stub-fake', chains: [1], enabled: false }),
+  },
+  chainAId: 1,
+  chainBId: 8453,
+}));

--- a/lido-service/src/app.ts
+++ b/lido-service/src/app.ts
@@ -1,13 +1,20 @@
 import express, { Request, Response, NextFunction } from 'express';
 import cors from 'cors';
 import { LidoRoutes } from './infrastructure/http/routes/lidoRoutes';
+import { buildStakingRouter } from './infrastructure/http/routes/staking.routes';
+import { buildStakingContainer, type StakingContainer } from './infrastructure/di/container';
 import { ErrorHandler } from './infrastructure/http/middleware/errorHandler';
 import { DatabaseService } from './infrastructure/database/database.service';
 import { EthereumConfig } from './infrastructure/config/ethereum';
 import { ERROR_CODES, sendError } from './shared/errorCodes';
 import { serializeByUser } from './middleware/serialize-by-user';
 
-export function createApp(): express.Express {
+export interface CreateAppOptions {
+  /** Inject a pre-built staking container — test convenience. Production builds default. */
+  stakingContainer?: StakingContainer;
+}
+
+export function createApp(options: CreateAppOptions = {}): express.Express {
   const app = express();
 
   app.use(cors());
@@ -58,7 +65,24 @@ export function createApp(): express.Express {
 
   app.use(serializeByUser);
 
-  app.use('/api/lido', LidoRoutes);
+  // Deprecated namespace — kept working for one release with a Deprecation header.
+  app.use(
+    '/api/lido',
+    (_req, res, next) => {
+      res.setHeader('Deprecation', 'true');
+      res.setHeader('Link', '</v1/capability/staking>; rel="successor-version"');
+      next();
+    },
+    LidoRoutes,
+  );
+
+  // Capability namespace — see SPRINT_HUGO.md card #246 and ADR 002 (capability + provider).
+  const stakingContainer = options.stakingContainer ?? buildStakingContainer();
+  stakingContainer.start();
+  app.use('/v1/capability/staking', buildStakingRouter({
+    facade: stakingContainer.facade,
+    discoveryHandler: stakingContainer.discoveryHandler,
+  }));
 
   app.get('/health', async (_req, res) => {
     let dbOk = false;

--- a/lido-service/src/application/services/__tests__/staking.capability.service.test.ts
+++ b/lido-service/src/application/services/__tests__/staking.capability.service.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Unit tests for StakingCapabilityService — facade orchestration.
+ *
+ * The facade is the hot path for every `/v1/capability/staking/*` request. These tests cover:
+ *  - happy path (single provider succeeds)
+ *  - fallback (first provider unsupports → next serves)
+ *  - validation errors rethrown without fallback
+ *  - empty candidate list → unsupportedRoute
+ *  - provider info + attempts surfaced in the outcome
+ *
+ * Real Lido contract calls are out of scope here; that's the adapter integration test.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  ChainAssetPriorityPolicy,
+  ProviderRegistry,
+  type CapabilityRequest,
+  type ProviderMetadata,
+  type Transaction,
+} from '@panorama/capability';
+
+import { StakingCapabilityService } from '../staking.capability.service';
+import type {
+  CapabilityStakingPosition,
+  IStakingProvider,
+  PrepareClaimInput,
+  PrepareStakeInput,
+  PrepareUnstakeInput,
+  StakingRouteParams,
+} from '../../../domain/ports/staking.provider.port';
+
+// -------------------------------------------------------------------------------------------------
+// Fake providers
+// -------------------------------------------------------------------------------------------------
+
+interface FakeOpts {
+  name: string;
+  supportedChains: number[];
+  enabled?: boolean;
+  supports?: boolean;
+  failPrepareStake?: 'validation' | 'provider' | false;
+  position?: CapabilityStakingPosition | null;
+}
+
+function fake(opts: FakeOpts): IStakingProvider {
+  const metadata: ProviderMetadata = {
+    name: opts.name,
+    capability: 'staking',
+    supportedChains: opts.supportedChains,
+    version: '1.0.0',
+    ...(opts.enabled !== undefined && { enabled: opts.enabled }),
+  };
+  const tx: Transaction = {
+    chainId: opts.supportedChains[0] as number,
+    to: '0xabc',
+    data: '0xdef',
+    value: '0',
+    action: 'stake',
+  };
+  const supports = opts.supports ?? true;
+  return {
+    name: opts.name,
+    metadata,
+    async supportsRoute(_params: StakingRouteParams): Promise<boolean> {
+      return supports;
+    },
+    async getPosition(): Promise<CapabilityStakingPosition | null> {
+      return opts.position ?? null;
+    },
+    async prepareStake(_input: PrepareStakeInput): Promise<Transaction[]> {
+      if (opts.failPrepareStake === 'validation') {
+        const { CapabilityError } = await import('@panorama/capability');
+        throw CapabilityError.validation({ capability: 'staking', message: `${opts.name} validation` });
+      }
+      if (opts.failPrepareStake === 'provider') {
+        const { CapabilityError } = await import('@panorama/capability');
+        throw CapabilityError.providerFailure({
+          capability: 'staking',
+          provider: opts.name,
+          message: `${opts.name} provider failure`,
+        });
+      }
+      return [{ ...tx, action: `stake-from-${opts.name}` }];
+    },
+    async prepareUnstake(_input: PrepareUnstakeInput): Promise<Transaction[]> {
+      return [{ ...tx, action: `unstake-from-${opts.name}` }];
+    },
+    async prepareClaim(_input: PrepareClaimInput): Promise<Transaction[]> {
+      return [{ ...tx, action: `claim-from-${opts.name}` }];
+    },
+    async getApr(_asset: string, _chainId: number): Promise<number | null> {
+      return opts.name === 'lido' ? 3.5 : null;
+    },
+  };
+}
+
+function envelope<T>(payload: T, chainId = 1, address = '0xuser'): CapabilityRequest<T> {
+  return {
+    tenantId: 't',
+    traceId: 'trace-1',
+    chainId,
+    userAddress: address,
+    payload,
+  };
+}
+
+function setup(providers: IStakingProvider[]): StakingCapabilityService {
+  const registry = new ProviderRegistry<IStakingProvider>();
+  for (const p of providers) registry.register(p);
+  const policy = new ChainAssetPriorityPolicy({
+    '1': providers.map((p) => p.name),
+  });
+  return new StakingCapabilityService({ registry, policy });
+}
+
+// -------------------------------------------------------------------------------------------------
+// Tests
+// -------------------------------------------------------------------------------------------------
+
+describe('StakingCapabilityService — getPosition', () => {
+  it('returns first supporting provider position', async () => {
+    const lido = fake({
+      name: 'lido',
+      supportedChains: [1],
+      position: {
+        stakedAmountWei: '1000',
+        receiptTokenBalanceWei: '999',
+        receiptTokenSymbol: 'stETH',
+        apr: 3.5,
+      },
+    });
+    const svc = setup([lido]);
+    const result = await svc.getPosition(envelope({}));
+    expect(result.data?.receiptTokenSymbol).toBe('stETH');
+    expect(result.provider.name).toBe('lido');
+  });
+
+  it('returns null when provider has no position', async () => {
+    const lido = fake({ name: 'lido', supportedChains: [1], position: null });
+    const svc = setup([lido]);
+    const r = await svc.getPosition(envelope({}));
+    expect(r.data).toBeNull();
+  });
+});
+
+describe('StakingCapabilityService — prepareStake', () => {
+  it('uses ranked-first supporting provider', async () => {
+    const lido = fake({ name: 'lido', supportedChains: [1] });
+    const fallback = fake({ name: 'fallback', supportedChains: [1] });
+    const svc = setup([lido, fallback]);
+    const r = await svc.prepareStake(envelope({ amount: '1000' }));
+    expect(r.provider.name).toBe('lido');
+    expect(r.data[0]?.action).toBe('stake-from-lido');
+  });
+
+  it('falls back when first provider does not support', async () => {
+    const a = fake({ name: 'a', supportedChains: [1], supports: false });
+    const b = fake({ name: 'b', supportedChains: [1] });
+    const svc = setup([a, b]);
+    const r = await svc.prepareStake(envelope({ amount: '1000' }));
+    expect(r.provider.name).toBe('b');
+    expect(r.attempts[0]?.provider).toBe('a');
+  });
+
+  it('rethrows validation errors immediately (no fallback)', async () => {
+    const a = fake({ name: 'a', supportedChains: [1], failPrepareStake: 'validation' });
+    const b = fake({ name: 'b', supportedChains: [1] });
+    const svc = setup([a, b]);
+    await expect(svc.prepareStake(envelope({ amount: '0' }))).rejects.toThrow(/a validation/);
+  });
+
+  it('falls back on PROVIDER_FAILURE', async () => {
+    const a = fake({ name: 'a', supportedChains: [1], failPrepareStake: 'provider' });
+    const b = fake({ name: 'b', supportedChains: [1] });
+    const svc = setup([a, b]);
+    const r = await svc.prepareStake(envelope({ amount: '1000' }));
+    expect(r.provider.name).toBe('b');
+    expect(r.attempts[0]?.reason).toMatch(/provider failure/);
+  });
+
+  it('throws unsupportedRoute when no candidates on chain', async () => {
+    const lido = fake({ name: 'lido', supportedChains: [1] });
+    const svc = setup([lido]);
+    await expect(
+      svc.prepareStake(envelope({ amount: '1000' }, 8453)),
+    ).rejects.toThrow(/UNSUPPORTED|No provider/);
+  });
+
+  it('excludes disabled stubs from candidate list', async () => {
+    const lido = fake({ name: 'lido', supportedChains: [1] });
+    const stub = fake({ name: 'stub', supportedChains: [1], enabled: false });
+    const svc = setup([lido, stub]);
+    const r = await svc.prepareStake(envelope({ amount: '1000' }));
+    expect(r.provider.name).toBe('lido');
+  });
+});
+
+describe('StakingCapabilityService — prepareUnstake / prepareClaim', () => {
+  it('prepareUnstake routes through fallback chain', async () => {
+    const lido = fake({ name: 'lido', supportedChains: [1] });
+    const svc = setup([lido]);
+    const r = await svc.prepareUnstake(envelope({ amount: '500' }));
+    expect(r.data[0]?.action).toBe('unstake-from-lido');
+  });
+
+  it('prepareClaim forwards requestIds', async () => {
+    const lido = fake({ name: 'lido', supportedChains: [1] });
+    const svc = setup([lido]);
+    const r = await svc.prepareClaim(envelope({ requestIds: ['1', '2'] }));
+    expect(r.data[0]?.action).toBe('claim-from-lido');
+  });
+});
+
+describe('StakingCapabilityService — getApr', () => {
+  it('returns first ranked provider apr', async () => {
+    const lido = fake({ name: 'lido', supportedChains: [1] });
+    const svc = setup([lido]);
+    const r = await svc.getApr(envelope({ asset: 'ETH' }));
+    expect(r.data).toBe(3.5);
+  });
+
+  it('returns null when provider does not know apr', async () => {
+    const other = fake({ name: 'other', supportedChains: [1] });
+    const svc = setup([other]);
+    const r = await svc.getApr(envelope({ asset: 'ETH' }));
+    expect(r.data).toBeNull();
+  });
+});
+
+describe('StakingCapabilityService — listProviders', () => {
+  it('returns capability=staking only', async () => {
+    const svc = setup([fake({ name: 'a', supportedChains: [1] })]);
+    expect(svc.listProviders().map((p) => p.name)).toEqual(['a']);
+  });
+});

--- a/lido-service/src/application/services/staking.capability.service.ts
+++ b/lido-service/src/application/services/staking.capability.service.ts
@@ -1,0 +1,190 @@
+/**
+ * StakingCapabilityService — facade for the staking capability.
+ *
+ * Orchestrates the `ProviderRegistry<IStakingProvider>` + `IPriorityPolicy` so the controller
+ * never knows about specific providers. All staking endpoints (`/v1/capability/staking/*`)
+ * go through this single class.
+ *
+ * Card #245 (SPRINT_HUGO.md).
+ */
+
+import {
+  CapabilityError,
+  fallbackInvoke,
+  type Address,
+  type CapabilityRequest,
+  type ChainId,
+  type IPriorityPolicy,
+  type ProviderRegistry,
+  type Transaction,
+} from '@panorama/capability';
+
+import {
+  type CapabilityStakingPosition,
+  type IStakingProvider,
+  type PrepareClaimInput,
+  type PrepareStakeInput,
+  type PrepareUnstakeInput,
+} from '../../domain/ports/staking.provider.port';
+
+export interface StakingFacadeDeps {
+  registry: ProviderRegistry<IStakingProvider>;
+  policy: IPriorityPolicy;
+}
+
+export interface StakingActionOutcome<TData> {
+  data: TData;
+  provider: { name: string; metadata?: Record<string, unknown> };
+  attempts: { provider: string; reason: string }[];
+}
+
+export class StakingCapabilityService {
+  private readonly registry: ProviderRegistry<IStakingProvider>;
+  private readonly policy: IPriorityPolicy;
+
+  constructor(deps: StakingFacadeDeps) {
+    this.registry = deps.registry;
+    this.policy = deps.policy;
+  }
+
+  // -----------------------------------------------------------------------------------------------
+  // Position (read)
+  // -----------------------------------------------------------------------------------------------
+
+  async getPosition(
+    req: CapabilityRequest<{ asset?: string }>,
+  ): Promise<StakingActionOutcome<CapabilityStakingPosition | null>> {
+    const ranked = this.rankCandidates(req.chainId, req.payload.asset);
+    const outcome = await fallbackInvoke({
+      ranked,
+      supportsRoute: (p) =>
+        p.supportsRoute({ chainId: req.chainId, asset: req.payload.asset }),
+      invoke: (p) => p.getPosition(req.userAddress, req.chainId),
+      capability: 'staking',
+    });
+    if (!outcome.ok) throw outcome.error;
+    return {
+      data: outcome.result,
+      provider: {
+        name: outcome.provider.name,
+        metadata: outcome.provider.metadata as unknown as Record<string, unknown>,
+      },
+      attempts: outcome.attempts,
+    };
+  }
+
+  // -----------------------------------------------------------------------------------------------
+  // Prepare actions
+  // -----------------------------------------------------------------------------------------------
+
+  async prepareStake(
+    req: CapabilityRequest<{ amount: string; asset?: string }>,
+  ): Promise<StakingActionOutcome<Transaction[]>> {
+    return this.runPrepare(req, (p, input) => p.prepareStake(input), 'prepareStake');
+  }
+
+  async prepareUnstake(
+    req: CapabilityRequest<{ amount: string; asset?: string }>,
+  ): Promise<StakingActionOutcome<Transaction[]>> {
+    return this.runPrepare(req, (p, input) => p.prepareUnstake(input), 'prepareUnstake');
+  }
+
+  async prepareClaim(
+    req: CapabilityRequest<{ requestIds?: string[]; asset?: string }>,
+  ): Promise<StakingActionOutcome<Transaction[]>> {
+    const ranked = this.rankCandidates(req.chainId, req.payload.asset);
+    const input: PrepareClaimInput = {
+      userAddress: req.userAddress,
+      chainId: req.chainId,
+      ...(req.payload.requestIds && { requestIds: req.payload.requestIds }),
+    };
+    const outcome = await fallbackInvoke({
+      ranked,
+      supportsRoute: (p) =>
+        p.supportsRoute({ chainId: req.chainId, asset: req.payload.asset }),
+      invoke: (p) => p.prepareClaim(input),
+      capability: 'staking',
+    });
+    if (!outcome.ok) throw outcome.error;
+    return {
+      data: outcome.result,
+      provider: { name: outcome.provider.name },
+      attempts: outcome.attempts,
+    };
+  }
+
+  // -----------------------------------------------------------------------------------------------
+  // APR (read)
+  // -----------------------------------------------------------------------------------------------
+
+  async getApr(
+    req: CapabilityRequest<{ asset?: string }>,
+  ): Promise<StakingActionOutcome<number | null>> {
+    const asset = req.payload.asset ?? 'ETH';
+    const ranked = this.rankCandidates(req.chainId, asset);
+    const outcome = await fallbackInvoke({
+      ranked,
+      supportsRoute: (p) => p.supportsRoute({ chainId: req.chainId, asset }),
+      invoke: (p) => p.getApr(asset, req.chainId),
+      capability: 'staking',
+    });
+    if (!outcome.ok) throw outcome.error;
+    return {
+      data: outcome.result,
+      provider: { name: outcome.provider.name },
+      attempts: outcome.attempts,
+    };
+  }
+
+  // -----------------------------------------------------------------------------------------------
+  // Internals
+  // -----------------------------------------------------------------------------------------------
+
+  private rankCandidates(chainId: ChainId, asset?: string): IStakingProvider[] {
+    const candidates = this.registry.listByChain(chainId, { capability: 'staking' });
+    if (candidates.length === 0) {
+      throw CapabilityError.unsupportedRoute({
+        capability: 'staking',
+        chainId,
+        attempted: [],
+        ...(asset && { fromAsset: asset }),
+      });
+    }
+    return this.policy.rank(candidates, { chainId, ...(asset && { asset }) });
+  }
+
+  private async runPrepare(
+    req: CapabilityRequest<{ amount: string; asset?: string }>,
+    invoke: (
+      p: IStakingProvider,
+      input: PrepareStakeInput | PrepareUnstakeInput,
+    ) => Promise<Transaction[]>,
+    action: string,
+  ): Promise<StakingActionOutcome<Transaction[]>> {
+    const ranked = this.rankCandidates(req.chainId, req.payload.asset);
+    const input: PrepareStakeInput = {
+      userAddress: req.userAddress as Address,
+      chainId: req.chainId,
+      amount: req.payload.amount,
+      ...(req.payload.asset && { asset: req.payload.asset }),
+    };
+    const outcome = await fallbackInvoke({
+      ranked,
+      supportsRoute: (p) =>
+        p.supportsRoute({ chainId: req.chainId, asset: req.payload.asset }),
+      invoke: (p) => invoke(p, input),
+      capability: 'staking',
+    });
+    if (!outcome.ok) throw outcome.error;
+    return {
+      data: outcome.result,
+      provider: { name: outcome.provider.name },
+      attempts: outcome.attempts,
+    };
+  }
+
+  // Exposed for the discovery handler.
+  listProviders(): IStakingProvider[] {
+    return this.registry.listAll({ capability: 'staking' });
+  }
+}

--- a/lido-service/src/domain/ports/staking.provider.port.ts
+++ b/lido-service/src/domain/ports/staking.provider.port.ts
@@ -1,0 +1,114 @@
+/**
+ * IStakingProvider — staking capability port.
+ *
+ * Every staking provider (Lido, Base cbETH stub, future sAVAX/sFRAX) implements this interface.
+ * The staking capability facade (`StakingCapabilityService`) speaks only this port — never an
+ * adapter concrete class.
+ *
+ * See ADR 002 (capability + provider) and CONVENTIONS.md from `@panorama/capability`.
+ *
+ * Card #244 (SPRINT_HUGO.md).
+ */
+
+import type {
+  Address,
+  ChainId,
+  ICapabilityProvider,
+  Transaction,
+} from "@panorama/capability";
+
+// -------------------------------------------------------------------------------------------------
+// Per-action request shapes (domain inputs that the port consumes)
+// -------------------------------------------------------------------------------------------------
+
+export interface StakingRouteParams {
+  chainId: ChainId;
+  /** Asset symbol or address. Optional — provider falls back to its default (usually native). */
+  asset?: string;
+}
+
+export interface PrepareStakeInput {
+  userAddress: Address;
+  chainId: ChainId;
+  /** Wei amount as decimal string. */
+  amount: string;
+  /** Asset symbol or address. */
+  asset?: string;
+}
+
+export interface PrepareUnstakeInput {
+  userAddress: Address;
+  chainId: ChainId;
+  amount: string;
+  asset?: string;
+}
+
+export interface PrepareClaimInput {
+  userAddress: Address;
+  chainId: ChainId;
+  /** Optional explicit withdrawal request ids (Lido uses these). */
+  requestIds?: string[];
+}
+
+// -------------------------------------------------------------------------------------------------
+// Domain entity returned by `getPosition` — kept minimal so all providers can populate it.
+// -------------------------------------------------------------------------------------------------
+
+export interface CapabilityStakingPosition {
+  /** Native staked amount in wei. */
+  stakedAmountWei: string;
+  /** Liquid receipt token balance (e.g. stETH for Lido). Wei. */
+  receiptTokenBalanceWei: string;
+  /** Receipt token symbol (e.g. "stETH"). */
+  receiptTokenSymbol: string;
+  /** Current APR (annualised yield) — null when unknown. */
+  apr: number | null;
+  /** Provider-specific extras (e.g. wstETH balance for Lido). */
+  extra?: Record<string, unknown>;
+}
+
+// -------------------------------------------------------------------------------------------------
+// The port
+// -------------------------------------------------------------------------------------------------
+
+export interface IStakingProvider extends ICapabilityProvider {
+  /**
+   * True if this provider can serve `chainId` (and optionally `asset`). The registry already
+   * filters by `metadata.supportedChains`; `supportsRoute` is for finer-grained filtering
+   * (e.g. Lido on Ethereum supports ETH but rejects USDC).
+   */
+  supportsRoute(params: StakingRouteParams): Promise<boolean>;
+
+  /**
+   * Get the user's current staking position. Returns null when the user has never staked
+   * with this provider.
+   */
+  getPosition(
+    userAddress: Address,
+    chainId: ChainId
+  ): Promise<CapabilityStakingPosition | null>;
+
+  /**
+   * Build the transactions needed to stake `input.amount` of the asset.
+   * Multi-step (approve + stake) returns multiple transactions in order.
+   */
+  prepareStake(input: PrepareStakeInput): Promise<Transaction[]>;
+
+  /**
+   * Build the transactions needed to unstake `input.amount`. For Lido this typically creates
+   * a withdrawal request the user later claims via `prepareClaim`.
+   */
+  prepareUnstake(input: PrepareUnstakeInput): Promise<Transaction[]>;
+
+  /**
+   * Build the transactions needed to claim finalized withdrawals.
+   * `input.requestIds` is mandatory for providers with explicit request queues (Lido); for
+   * providers with implicit claims (e.g. liquid restaking) the field is ignored.
+   */
+  prepareClaim(input: PrepareClaimInput): Promise<Transaction[]>;
+
+  /**
+   * Current APR for `asset` on `chainId`. Null when the provider can't report APR.
+   */
+  getApr(asset: string, chainId: ChainId): Promise<number | null>;
+}

--- a/lido-service/src/infrastructure/adapters/base-staking.provider.adapter.ts
+++ b/lido-service/src/infrastructure/adapters/base-staking.provider.adapter.ts
@@ -1,0 +1,77 @@
+/**
+ * BaseStakingProviderAdapter — stub for future Base-chain staking (e.g. cbETH).
+ *
+ * Ships structurally complete with `metadata.enabled = false` so the registry skips it by
+ * default. This guarantees the registry/policy/discovery code paths are exercised against
+ * multi-provider shapes without committing to a half-baked Base staking implementation.
+ *
+ * Card #248 (SPRINT_HUGO.md).
+ */
+
+import {
+  CapabilityError,
+  type Address,
+  type ChainId,
+  type ProviderMetadata,
+  type Transaction,
+} from '@panorama/capability';
+import { getChain } from '@panorama/capability/chains';
+
+import {
+  type CapabilityStakingPosition,
+  type IStakingProvider,
+  type PrepareClaimInput,
+  type PrepareStakeInput,
+  type PrepareUnstakeInput,
+  type StakingRouteParams,
+} from '../../domain/ports/staking.provider.port';
+
+const BASE_CHAIN_ID = getChain('base').id;
+
+export class BaseStakingProviderAdapter implements IStakingProvider {
+  public readonly name = 'base-staking-stub';
+  public readonly metadata: ProviderMetadata = {
+    name: 'base-staking-stub',
+    capability: 'staking',
+    supportedChains: [BASE_CHAIN_ID],
+    features: ['cbETH', 'stub'],
+    version: '0.0.0',
+    enabled: false,
+  };
+
+  async supportsRoute(_params: StakingRouteParams): Promise<boolean> {
+    return false;
+  }
+
+  async getPosition(
+    _userAddress: Address,
+    _chainId: ChainId,
+  ): Promise<CapabilityStakingPosition | null> {
+    return null;
+  }
+
+  async prepareStake(_input: PrepareStakeInput): Promise<Transaction[]> {
+    throw CapabilityError.unavailable(
+      'Base staking provider is not implemented yet. Track progress via the cbETH adapter card.',
+      { provider: this.name },
+    );
+  }
+
+  async prepareUnstake(_input: PrepareUnstakeInput): Promise<Transaction[]> {
+    throw CapabilityError.unavailable(
+      'Base staking provider is not implemented yet.',
+      { provider: this.name },
+    );
+  }
+
+  async prepareClaim(_input: PrepareClaimInput): Promise<Transaction[]> {
+    throw CapabilityError.unavailable(
+      'Base staking provider is not implemented yet.',
+      { provider: this.name },
+    );
+  }
+
+  async getApr(_asset: string, _chainId: ChainId): Promise<number | null> {
+    return null;
+  }
+}

--- a/lido-service/src/infrastructure/adapters/lido.provider.adapter.ts
+++ b/lido-service/src/infrastructure/adapters/lido.provider.adapter.ts
@@ -1,0 +1,226 @@
+/**
+ * LidoProviderAdapter — wraps the existing `LidoService` behind the `IStakingProvider` port.
+ *
+ * The legacy `LidoService` retains its own callers (the deprecated `/api/lido/*` routes) — this
+ * adapter is a façade that lets the new `/v1/capability/staking/*` namespace consume the same
+ * underlying logic without forcing a full rewrite of the service in this PR.
+ *
+ * Card #247 (SPRINT_HUGO.md).
+ */
+
+import {
+  CapabilityError,
+  ErrorCategory,
+  type Address,
+  type ChainId,
+  type ProviderMetadata,
+  type Transaction,
+} from '@panorama/capability';
+import { getChain } from '@panorama/capability/chains';
+
+import {
+  type CapabilityStakingPosition,
+  type IStakingProvider,
+  type PrepareClaimInput,
+  type PrepareStakeInput,
+  type PrepareUnstakeInput,
+  type StakingRouteParams,
+} from '../../domain/ports/staking.provider.port';
+import { LidoService } from '../../application/services/LidoService';
+import { Logger } from '../logs/logger';
+
+const ETHEREUM_CHAIN_ID = getChain('ethereum').id;
+
+export interface LidoProviderAdapterDeps {
+  lidoService: LidoService;
+  logger?: Logger;
+}
+
+export class LidoProviderAdapter implements IStakingProvider {
+  public readonly name = 'lido';
+  public readonly metadata: ProviderMetadata = {
+    name: 'lido',
+    capability: 'staking',
+    supportedChains: [ETHEREUM_CHAIN_ID],
+    features: ['stETH', 'wstETH', 'withdrawal-queue'],
+    version: '1.0.0',
+    enabled: true,
+  };
+
+  private readonly lidoService: LidoService;
+  private readonly logger?: Logger;
+
+  constructor(deps: LidoProviderAdapterDeps) {
+    this.lidoService = deps.lidoService;
+    this.logger = deps.logger;
+  }
+
+  // -----------------------------------------------------------------------------------------------
+  // ICapabilityProvider
+  // -----------------------------------------------------------------------------------------------
+
+  async healthCheck(): Promise<{ healthy: boolean; latencyMs?: number; reason?: string; checkedAt: string }> {
+    const start = Date.now();
+    try {
+      // Cheapest available probe — fetch protocol info (cached upstream).
+      await this.lidoService.getProtocolInfo();
+      return {
+        healthy: true,
+        latencyMs: Date.now() - start,
+        checkedAt: new Date().toISOString(),
+      };
+    } catch (e) {
+      return {
+        healthy: false,
+        latencyMs: Date.now() - start,
+        reason: (e as Error).message,
+        checkedAt: new Date().toISOString(),
+      };
+    }
+  }
+
+  // -----------------------------------------------------------------------------------------------
+  // IStakingProvider
+  // -----------------------------------------------------------------------------------------------
+
+  async supportsRoute(params: StakingRouteParams): Promise<boolean> {
+    if (params.chainId !== ETHEREUM_CHAIN_ID) return false;
+    if (params.asset && params.asset.toUpperCase() !== 'ETH') return false;
+    return true;
+  }
+
+  async getPosition(
+    userAddress: Address,
+    chainId: ChainId,
+  ): Promise<CapabilityStakingPosition | null> {
+    this.ensureChain(chainId, 'getPosition');
+    const pos = await this.lidoService.getStakingPosition(userAddress);
+    if (!pos) return null;
+    return {
+      stakedAmountWei: pos.stakedAmount,
+      receiptTokenBalanceWei: pos.stETHBalance ?? '0',
+      receiptTokenSymbol: 'stETH',
+      apr: pos.apy,
+      extra: {
+        wstETHBalanceWei: pos.wstETHBalance ?? '0',
+        status: pos.status,
+      },
+    };
+  }
+
+  async prepareStake(input: PrepareStakeInput): Promise<Transaction[]> {
+    this.ensureChain(input.chainId, 'prepareStake');
+    try {
+      const tx = await this.lidoService.stake(input.userAddress, input.amount);
+      return this.unwrapTransactions(tx.transactionData, input.chainId, 'stake');
+    } catch (e) {
+      throw this.toCapabilityError(e, 'prepareStake');
+    }
+  }
+
+  async prepareUnstake(input: PrepareUnstakeInput): Promise<Transaction[]> {
+    this.ensureChain(input.chainId, 'prepareUnstake');
+    try {
+      const tx = await this.lidoService.unstake(input.userAddress, input.amount);
+      return this.unwrapTransactions(tx.transactionData, input.chainId, 'unstake');
+    } catch (e) {
+      throw this.toCapabilityError(e, 'prepareUnstake');
+    }
+  }
+
+  async prepareClaim(input: PrepareClaimInput): Promise<Transaction[]> {
+    this.ensureChain(input.chainId, 'prepareClaim');
+    if (!input.requestIds || input.requestIds.length === 0) {
+      throw CapabilityError.validation({
+        capability: 'staking',
+        message: 'lido provider requires requestIds for prepareClaim',
+        errors: [{ field: 'requestIds', reason: 'missing' }],
+      });
+    }
+    try {
+      const tx = await this.lidoService.claimWithdrawals(
+        input.userAddress,
+        input.requestIds,
+      );
+      return this.unwrapTransactions(tx.transactionData, input.chainId, 'claim-withdrawals');
+    } catch (e) {
+      throw this.toCapabilityError(e, 'prepareClaim');
+    }
+  }
+
+  async getApr(asset: string, chainId: ChainId): Promise<number | null> {
+    if (chainId !== ETHEREUM_CHAIN_ID) return null;
+    if (asset.toUpperCase() !== 'ETH') return null;
+    const info = await this.lidoService.getProtocolInfo();
+    return info.currentAPY;
+  }
+
+  // -----------------------------------------------------------------------------------------------
+  // Internals
+  // -----------------------------------------------------------------------------------------------
+
+  private ensureChain(chainId: ChainId, where: string): void {
+    if (chainId !== ETHEREUM_CHAIN_ID) {
+      throw CapabilityError.unsupportedRoute({
+        capability: 'staking',
+        chainId,
+        attempted: ['lido'],
+        fromAsset: 'ETH',
+        toAsset: 'stETH',
+      });
+    }
+    this.logger?.info(`[LidoProviderAdapter] ${where} chain=${chainId}`);
+  }
+
+  /**
+   * Convert the legacy `StakingTransaction.transactionData` into the envelope `Transaction[]`.
+   *
+   * `transactionData` carries a single tx today; when LidoService eventually issues multi-step
+   * bundles (stake-with-permit), this method returns more entries. Always returns at least one.
+   */
+  private unwrapTransactions(
+    data: { to: string; data: string; value: string; gasLimit: string; chainId: number } | undefined,
+    expectedChainId: ChainId,
+    action: string,
+  ): Transaction[] {
+    if (!data) {
+      throw new CapabilityError({
+        code: 'CAPABILITY_STAKING_PROVIDER_FAILURE',
+        category: ErrorCategory.PROVIDER_FAILURE,
+        message: `Lido did not return transaction data for ${action}`,
+        provider: 'lido',
+      });
+    }
+    return [
+      {
+        chainId: data.chainId ?? expectedChainId,
+        to: data.to,
+        data: data.data,
+        value: data.value,
+        gasLimit: data.gasLimit,
+        action,
+      },
+    ];
+  }
+
+  private toCapabilityError(e: unknown, where: string): CapabilityError {
+    if (CapabilityError.is(e)) return e;
+    const message = (e as Error).message ?? String(e);
+    if (/Insufficient stETH/i.test(message)) {
+      return CapabilityError.validation({
+        capability: 'staking',
+        message,
+        errors: [{ field: 'amount', reason: 'insufficient-balance' }],
+      });
+    }
+    if (/Amount must be greater than 0|Amount is required|wei string/i.test(message)) {
+      return CapabilityError.validation({ capability: 'staking', message });
+    }
+    return CapabilityError.providerFailure({
+      capability: 'staking',
+      provider: 'lido',
+      message: `lido ${where} failed: ${message}`,
+      cause: e,
+    });
+  }
+}

--- a/lido-service/src/infrastructure/di/container.ts
+++ b/lido-service/src/infrastructure/di/container.ts
@@ -1,0 +1,101 @@
+/**
+ * Composition root for the staking capability.
+ *
+ * Builds the registry, instantiates concrete adapters (Lido + Base stub), wires the policy,
+ * mounts the health tracker, and returns the facade + discovery handler. The HTTP layer
+ * (`staking.routes.ts`) consumes only what's returned here.
+ *
+ * Card #245 (SPRINT_HUGO.md).
+ */
+
+import {
+  ChainAssetPriorityPolicy,
+  ProviderHealthTracker,
+  ProviderRegistry,
+  createDiscoveryHandler,
+  type DiscoveryHandler,
+} from '@panorama/capability';
+import { getChain } from '@panorama/capability/chains';
+
+import { LidoProviderAdapter } from '../adapters/lido.provider.adapter';
+import { BaseStakingProviderAdapter } from '../adapters/base-staking.provider.adapter';
+import {
+  StakingCapabilityService,
+} from '../../application/services/staking.capability.service';
+import type { IStakingProvider } from '../../domain/ports/staking.provider.port';
+import { LidoService } from '../../application/services/LidoService';
+import { LidoRepository } from '../repositories/LidoRepository';
+import { Logger } from '../logs/logger';
+
+export interface StakingContainer {
+  facade: StakingCapabilityService;
+  registry: ProviderRegistry<IStakingProvider>;
+  healthTracker: ProviderHealthTracker;
+  discoveryHandler: DiscoveryHandler;
+  start(): void;
+  stop(): void;
+}
+
+export interface BuildStakingContainerOptions {
+  /** Inject when testing — skips ProviderHealthTracker autostart. */
+  autoStartHealth?: boolean;
+  /** Override Lido provider (test convenience). When absent, builds the default Lido stack. */
+  lidoProvider?: IStakingProvider;
+}
+
+export function buildStakingContainer(
+  options: BuildStakingContainerOptions = {},
+): StakingContainer {
+  const logger = new Logger();
+  const registry = new ProviderRegistry<IStakingProvider>();
+
+  // Lido — main production provider on Ethereum.
+  const lido =
+    options.lidoProvider ??
+    new LidoProviderAdapter({
+      lidoService: new LidoService(new LidoRepository(), logger),
+      logger,
+    });
+  registry.register(lido);
+
+  // Base cbETH — stub, disabled by default (registry skips by default; opt-in via includeDisabled).
+  registry.register(new BaseStakingProviderAdapter());
+
+  // Policy — single-provider per chain today; declared so adding cbETH later is config-only.
+  const policy = new ChainAssetPriorityPolicy({
+    [String(getChain('ethereum').id)]: ['lido'],
+    [String(getChain('base').id)]: ['base-staking-stub'],
+  });
+
+  // Health tracker — polls every 30s by default; respects ProviderRegistry filter.
+  const healthTracker = new ProviderHealthTracker({
+    intervalMs: 30_000,
+    unhealthyAfter: 3,
+    probeTimeoutMs: 5_000,
+    onError: (name, error) => logger.warn(`[health] ${name} probe failed: ${(error as Error).message}`),
+  });
+  registry.attachHealthOracle(healthTracker);
+  healthTracker.track(lido);
+  // Stub doesn't need probing — keeps it out of report noise.
+
+  const facade = new StakingCapabilityService({ registry, policy });
+
+  const discoveryHandler = createDiscoveryHandler({
+    listProviders: () => registry.listAll(),
+    snapshotHealth: () => healthTracker.snapshot(),
+    cacheTtlSeconds: 30,
+  });
+
+  return {
+    facade,
+    registry,
+    healthTracker,
+    discoveryHandler,
+    start: () => {
+      if (options.autoStartHealth !== false) healthTracker.start();
+    },
+    stop: () => {
+      healthTracker.stop();
+    },
+  };
+}

--- a/lido-service/src/infrastructure/http/controllers/StakingController.ts
+++ b/lido-service/src/infrastructure/http/controllers/StakingController.ts
@@ -1,0 +1,249 @@
+/**
+ * StakingController — thin HTTP adapter on top of `StakingCapabilityService`.
+ *
+ * Parses the request, constructs a `CapabilityRequest<T>`, calls the facade, wraps the result
+ * in `CapabilityResponse<T>`. No business logic — that's the facade's job.
+ *
+ * Card #246 (SPRINT_HUGO.md).
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { Request, Response } from 'express';
+
+import {
+  CapabilityError,
+  buildError,
+  buildSuccess,
+  type CapabilityRequest,
+  type ProviderInfo,
+  type Uuid,
+} from '@panorama/capability';
+
+import {
+  StakingCapabilityService,
+  type StakingActionOutcome,
+} from '../../../application/services/staking.capability.service';
+import type { DiscoveryHandler } from '@panorama/capability';
+
+export interface StakingControllerDeps {
+  facade: StakingCapabilityService;
+  discoveryHandler: DiscoveryHandler;
+}
+
+export class StakingController {
+  private readonly facade: StakingCapabilityService;
+  private readonly discoveryHandler: DiscoveryHandler;
+
+  constructor(deps: StakingControllerDeps) {
+    this.facade = deps.facade;
+    this.discoveryHandler = deps.discoveryHandler;
+  }
+
+  // -----------------------------------------------------------------------------------------------
+  // Endpoints
+  // -----------------------------------------------------------------------------------------------
+
+  /** GET /v1/capability/staking/_discovery */
+  discovery(req: Request, res: Response): void {
+    const result = this.discoveryHandler({ traceId: this.traceFor(req) });
+    res.status(200).json(result);
+  }
+
+  /** GET /v1/capability/staking/position/:address?asset=ETH */
+  async getPosition(req: Request, res: Response): Promise<void> {
+    await this.runQuery<{ asset?: string }>(req, res, async (envelope) => {
+      const outcome = await this.facade.getPosition(envelope);
+      return this.toResponse(outcome, envelope.traceId);
+    }, {
+      override: {
+        userAddress: req.params.address as string,
+        payload: req.query.asset ? { asset: req.query.asset as string } : {},
+      },
+    });
+  }
+
+  /** POST /v1/capability/staking/prepare-stake */
+  async prepareStake(req: Request, res: Response): Promise<void> {
+    await this.runCommand<{ amount: string; asset?: string }>(
+      req,
+      res,
+      async (envelope) => {
+        const outcome = await this.facade.prepareStake(envelope);
+        return this.toResponse(outcome, envelope.traceId);
+      },
+    );
+  }
+
+  /** POST /v1/capability/staking/prepare-unstake */
+  async prepareUnstake(req: Request, res: Response): Promise<void> {
+    await this.runCommand<{ amount: string; asset?: string }>(
+      req,
+      res,
+      async (envelope) => {
+        const outcome = await this.facade.prepareUnstake(envelope);
+        return this.toResponse(outcome, envelope.traceId);
+      },
+    );
+  }
+
+  /** POST /v1/capability/staking/prepare-claim */
+  async prepareClaim(req: Request, res: Response): Promise<void> {
+    await this.runCommand<{ requestIds?: string[]; asset?: string }>(
+      req,
+      res,
+      async (envelope) => {
+        const outcome = await this.facade.prepareClaim(envelope);
+        return this.toResponse(outcome, envelope.traceId);
+      },
+    );
+  }
+
+  /** GET /v1/capability/staking/apr?asset=ETH&chainId=1 */
+  async getApr(req: Request, res: Response): Promise<void> {
+    await this.runQuery<{ asset?: string }>(req, res, async (envelope) => {
+      const outcome = await this.facade.getApr(envelope);
+      return this.toResponse(outcome, envelope.traceId);
+    });
+  }
+
+  // -----------------------------------------------------------------------------------------------
+  // Request parsing
+  // -----------------------------------------------------------------------------------------------
+
+  private async runCommand<TPayload>(
+    req: Request,
+    res: Response,
+    handler: (envelope: CapabilityRequest<TPayload>) => Promise<{
+      status: number;
+      body: ReturnType<typeof buildSuccess<unknown>> | ReturnType<typeof buildError>;
+    }>,
+  ): Promise<void> {
+    const traceId = this.traceFor(req);
+    const start = Date.now();
+    try {
+      const envelope = this.buildEnvelope<TPayload>(req, traceId, { fromBody: true });
+      const { status, body } = await handler(envelope);
+      res.status(status).json(body);
+    } catch (e) {
+      const err = CapabilityError.is(e) ? e : CapabilityError.internal(
+        `staking controller error: ${(e as Error).message}`,
+        e,
+      );
+      const errBody = buildError({
+        error: err,
+        traceId,
+        latencyMs: Date.now() - start,
+      });
+      res.status(err.httpStatus).json(errBody);
+    }
+  }
+
+  private async runQuery<TPayload>(
+    req: Request,
+    res: Response,
+    handler: (envelope: CapabilityRequest<TPayload>) => Promise<{
+      status: number;
+      body: ReturnType<typeof buildSuccess<unknown>> | ReturnType<typeof buildError>;
+    }>,
+    options?: { override?: Partial<CapabilityRequest<TPayload>> },
+  ): Promise<void> {
+    const traceId = this.traceFor(req);
+    const start = Date.now();
+    try {
+      const envelope = this.buildEnvelope<TPayload>(req, traceId, { fromBody: false, override: options?.override });
+      const { status, body } = await handler(envelope);
+      res.status(status).json(body);
+    } catch (e) {
+      const err = CapabilityError.is(e) ? e : CapabilityError.internal(
+        `staking controller error: ${(e as Error).message}`,
+        e,
+      );
+      const errBody = buildError({
+        error: err,
+        traceId,
+        latencyMs: Date.now() - start,
+      });
+      res.status(err.httpStatus).json(errBody);
+    }
+  }
+
+  // -----------------------------------------------------------------------------------------------
+  // Helpers
+  // -----------------------------------------------------------------------------------------------
+
+  private toResponse<TData>(
+    outcome: StakingActionOutcome<TData>,
+    traceId: Uuid,
+  ): {
+    status: number;
+    body: ReturnType<typeof buildSuccess<TData>>;
+  } {
+    const provider: ProviderInfo = outcome.provider;
+    const body = buildSuccess<TData>({
+      data: outcome.data,
+      provider,
+      traceId,
+      latencyMs: 0,
+      ...(outcome.attempts.length > 0 && {
+        attemptedProviders: outcome.attempts.map((a) => ({ name: a.provider, reason: a.reason })),
+      }),
+    });
+    return { status: 200, body };
+  }
+
+  private buildEnvelope<TPayload>(
+    req: Request,
+    traceId: Uuid,
+    options: { fromBody: boolean; override?: Partial<CapabilityRequest<TPayload>> },
+  ): CapabilityRequest<TPayload> {
+    const tenantId =
+      (req.headers['x-tenant-id'] as string | undefined) ??
+      ((req as { user?: { address?: string } }).user?.address ?? 'anonymous');
+    const idempotencyKey = req.headers['x-idempotency-key'] as string | undefined;
+    const chainId = this.parseChainId(req);
+    const userAddressRaw =
+      options.fromBody
+        ? (req.body?.userAddress as string | undefined)
+        : (req.params.address as string | undefined) ??
+          (req.query.address as string | undefined);
+    if (!userAddressRaw) {
+      throw CapabilityError.validation({
+        capability: 'staking',
+        message: 'userAddress is required (body for POST, :address path or ?address query for GET)',
+      });
+    }
+
+    const payload = options.fromBody ? (req.body as TPayload) : ({} as TPayload);
+
+    const envelope: CapabilityRequest<TPayload> = {
+      tenantId,
+      traceId,
+      chainId,
+      userAddress: userAddressRaw,
+      payload,
+      ...(idempotencyKey && { idempotencyKey }),
+      receivedAt: new Date().toISOString(),
+      ...options.override,
+    };
+    return envelope;
+  }
+
+  private parseChainId(req: Request): number {
+    const raw = (req.headers['x-chain-id'] as string | undefined)
+      ?? (req.body?.chainId as number | string | undefined)
+      ?? (req.query.chainId as string | undefined)
+      ?? '1';
+    const parsed = typeof raw === 'number' ? raw : parseInt(raw, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      throw CapabilityError.validation({
+        capability: 'staking',
+        message: `Invalid chainId: ${JSON.stringify(raw)}`,
+      });
+    }
+    return parsed;
+  }
+
+  private traceFor(req: Request): Uuid {
+    return (req.headers['x-trace-id'] as string | undefined) ?? randomUUID();
+  }
+}

--- a/lido-service/src/infrastructure/http/routes/staking.routes.ts
+++ b/lido-service/src/infrastructure/http/routes/staking.routes.ts
@@ -1,0 +1,68 @@
+/**
+ * Routes for `/v1/capability/staking/*`.
+ *
+ * Mounted in `app.ts` alongside the deprecated `/api/lido/*` routes (which keep working with a
+ * `Deprecation: true` header for one release).
+ *
+ * Card #246 (SPRINT_HUGO.md).
+ */
+
+import { Router } from 'express';
+
+import { AuthMiddleware } from '../middleware/auth';
+import { ErrorHandler } from '../middleware/errorHandler';
+import { StakingController } from '../controllers/StakingController';
+import type { StakingCapabilityService } from '../../../application/services/staking.capability.service';
+import type { DiscoveryHandler } from '@panorama/capability';
+
+export interface StakingRoutesDeps {
+  facade: StakingCapabilityService;
+  discoveryHandler: DiscoveryHandler;
+}
+
+export function buildStakingRouter(deps: StakingRoutesDeps): Router {
+  const router = Router();
+  const ctrl = new StakingController({
+    facade: deps.facade,
+    discoveryHandler: deps.discoveryHandler,
+  });
+
+  // Public — used by FE / agents to know who's healthy.
+  router.get(
+    '/_discovery',
+    ErrorHandler.asyncWrapper((req, res) => Promise.resolve(ctrl.discovery(req, res))),
+  );
+
+  // Public — APR + position can be read without auth (matches existing /api/lido/protocol/info policy).
+  router.get(
+    '/apr',
+    ErrorHandler.asyncWrapper((req, res) => ctrl.getApr(req, res)),
+  );
+  router.get(
+    '/position/:address',
+    AuthMiddleware.optionalAuth,
+    ErrorHandler.asyncWrapper((req, res) => ctrl.getPosition(req, res)),
+  );
+
+  // Auth-required: state-mutating prepare endpoints.
+  router.post(
+    '/prepare-stake',
+    AuthMiddleware.authenticate,
+    AuthMiddleware.requireBodyUserAddress(),
+    ErrorHandler.asyncWrapper((req, res) => ctrl.prepareStake(req, res)),
+  );
+  router.post(
+    '/prepare-unstake',
+    AuthMiddleware.authenticate,
+    AuthMiddleware.requireBodyUserAddress(),
+    ErrorHandler.asyncWrapper((req, res) => ctrl.prepareUnstake(req, res)),
+  );
+  router.post(
+    '/prepare-claim',
+    AuthMiddleware.authenticate,
+    AuthMiddleware.requireBodyUserAddress(),
+    ErrorHandler.asyncWrapper((req, res) => ctrl.prepareClaim(req, res)),
+  );
+
+  return router;
+}

--- a/lido-service/tsconfig.json
+++ b/lido-service/tsconfig.json
@@ -3,7 +3,6 @@
     "target": "es2020",
     "module": "commonjs",
     "outDir": "./dist",
-    "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
@@ -13,8 +12,20 @@
     "types": ["node"],
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
-    "noImplicitAny": false
+    "noImplicitAny": false,
+    "baseUrl": "./",
+    "paths": {
+      "@panorama/capability": ["../shared/capability/index.ts"],
+      "@panorama/capability/*": ["../shared/capability/*"]
+    }
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "../shared/capability/node_modules",
+    "../shared/capability/__tests__",
+    "../shared/capability/chains/__tests__",
+    "../shared/capability/http/__tests__"
+  ]
 }

--- a/lido-service/vitest.config.ts
+++ b/lido-service/vitest.config.ts
@@ -1,6 +1,20 @@
 import { defineConfig } from 'vitest/config';
+import { resolve } from 'node:path';
 
 export default defineConfig({
+  resolve: {
+    // Use regex matchers so any sub-path resolves (e.g. /__tests__/registry.conformance, /chains).
+    alias: [
+      {
+        find: /^@panorama\/capability$/,
+        replacement: resolve(__dirname, '../shared/capability/index.ts'),
+      },
+      {
+        find: /^@panorama\/capability\/(.+)$/,
+        replacement: resolve(__dirname, '../shared/capability/$1'),
+      },
+    ],
+  },
   test: {
     environment: 'node',
     include: ['src/**/__tests__/**/*.test.ts'],


### PR DESCRIPTION
> **Stacked PR** — base = `feat/hugo-capability-bloco-4` (Bloco 4 #279). When the chain merges into develop, this retargets automatically.

## Cards

- Closes Panorama-Block/panoramablock-backend#244 — Document staking capability interface
- Closes Panorama-Block/panoramablock-backend#245 — Generalize staking capability facade
- Closes Panorama-Block/panoramablock-backend#246 — Generalize staking capability endpoint namespace
- Closes Panorama-Block/panoramablock-backend#247 — Wrap Lido as staking capability provider
- Closes Panorama-Block/panoramablock-backend#248 — Define Base staking provider adapter stub
- Closes Panorama-Block/panoramablock-backend#249 — Add staking provider conformance tests

## Mudanças

Primeira capability a consumir `@panorama/capability` ponta a ponta. Migra `lido-service` para o padrão capability+provider sem quebrar nada do legacy.

### Arquivos novos em `backend/lido-service/`

| Card | Arquivo | O que faz |
|---|---|---|
| #244 | `src/domain/ports/staking.provider.port.ts` | `IStakingProvider extends ICapabilityProvider`, tipos de input/output do domínio (`PrepareStakeInput`, `CapabilityStakingPosition`) |
| #245 | `src/application/services/staking.capability.service.ts` | Facade que orquestra registry + policy + `fallbackInvoke` para cada ação |
| #245 | `src/infrastructure/di/container.ts` | Composition root: instancia adapters, monta policy/health/discovery |
| #246 | `src/infrastructure/http/controllers/StakingController.ts` | HTTP adapter — parse → envelope → facade → wrap response |
| #246 | `src/infrastructure/http/routes/staking.routes.ts` | Rotas `/v1/capability/staking/*` (`_discovery`, `apr`, `position/:address`, `prepare-{stake,unstake,claim}`) |
| #247 | `src/infrastructure/adapters/lido.provider.adapter.ts` | Wraps `LidoService` legacy como `IStakingProvider`, mapeia `StakingTransaction.transactionData` → `Transaction[]`, classifica erros em `CapabilityError` |
| #248 | `src/infrastructure/adapters/base-staking.provider.adapter.ts` | Stub cbETH (`metadata.enabled = false`) pra exercitar paths de multi-provider |
| #249 | `src/__tests__/staking.conformance.test.ts` | Roda `describeRegistryConformance` helper do shared package contra fake staking |
| #249 | `src/application/services/__tests__/staking.capability.service.test.ts` | 13 testes de orquestração da facade (happy path, fallback, validation errors) |

### Arquivos modificados

- `tsconfig.json` — `baseUrl` + `paths` apontando para `../shared/capability/*`
- `vitest.config.ts` — regex alias `@panorama/capability/<*>` → `../shared/capability/<*>`
- `app.ts` — monta `/v1/capability/staking/*`; `/api/lido/*` ganha `Deprecation: true` + `Link: rel="successor-version"` headers

### LidoService legacy: intocada

Continua servindo `/api/lido/*` exatamente como antes. O adapter consome `LidoService` como caixa preta — sem rewrite agora. Migração total + remoção da legacy fica para release seguinte (1 ciclo de bake mínimo, regra de backward compat do ADR 001).

## Tests

```
lido-service: 45/45 passing (legacy 17 + new 28)
@panorama/capability: 202/202 passing (sanity, sem mudanças)
typecheck: clean em ambos
```

- 13 facade tests (StakingCapabilityService): happy path / fallback / validation rethrow / unsupported-route / disabled stub exclusion
- 15 conformance assertions (via describeRegistryConformance helper)
- 17 testes legacy do lido (LidoController/Repository/usecases/validation) seguem verdes

## Como rodar local

```bash
cd backend/lido-service
npm test                                        # vitest
npx tsc --noEmit                                # typecheck

# Smoke do novo endpoint (after `npm run dev`):
curl http://localhost:3004/v1/capability/staking/_discovery | jq
curl -H 'x-chain-id: 1' http://localhost:3004/v1/capability/staking/apr?asset=ETH | jq
```

## Camada / DoD

- [x] Testes locais passando (45/45 lido + 202/202 shared)
- [x] Typecheck clean
- [x] Sem mudanças fora de `lido-service/` (e `shared/capability/` que é trilha minha)
- [x] Backward-compat: `/api/lido/*` continua + ganhou `Deprecation` header
- [x] Doc inline em cada novo módulo
- [ ] Review approved por par (Coletto primário, Rizzi secundário)

## Notas pra review

- **PR stacked**: base = `feat/hugo-capability-bloco-4`. Mergeia depois de #279 → #278 → #277.
- `LidoProviderAdapter.unwrapTransactions` adapta a forma legacy do StakingTransaction. Quando `LidoService` evoluir pra retornar bundles multi-step (stake-with-permit), este método retorna mais entries — sem mudança no port nem no facade.
- `LidoProviderAdapter.toCapabilityError` faz pattern-match em mensagens conhecidas do LidoService ("Insufficient stETH", "Amount must be greater than 0"...) para classificar em `VALIDATION` vs `PROVIDER_FAILURE`. Provisório até `LidoService` jogar `CapabilityError` direto.
- Integration test forking mainnet contra Lido **não** está neste PR (regra do projeto: forked, never mocks). Vem em follow-up; o conformance test cobre só o contrato de registry, não o adapter real.
- `app.ts.createApp(options.stakingContainer)` permite injetar container em testes futuros sem auto-start do health tracker.