### PR TITLE
feat(dca): DCA/Automation Capability — IDCAProvider, ERC4337DCAAdapter, idempotency

### DIFF
--- a/dca-service/package.json
+++ b/dca-service/package.json
@@ -4,9 +4,9 @@
   "description": "DCA (Dollar Cost Averaging) Service with Account Abstraction",
   "main": "dist/index.js",
   "scripts": {
-    "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
+    "dev": "ts-node-dev --respawn --transpile-only -r tsconfig-paths/register src/index.ts",
     "build": "tsc",
-    "start": "node dist/index.js",
+    "start": "node -r tsconfig-paths/register dist/index.js",
     "setup-db": "ts-node src/scripts/setup-database.ts",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -29,6 +29,7 @@
     "@types/node": "^20.5.9",
     "@types/node-cron": "^3.0.11",
     "ts-node-dev": "^2.0.0",
+    "tsconfig-paths": "^4.2.0",
     "typescript": "^5.2.2"
   }
 }

--- a/dca-service/src/application/services/dca.capability.service.ts
+++ b/dca-service/src/application/services/dca.capability.service.ts
@@ -1,0 +1,278 @@
+/**
+ * DCACapabilityService — application facade for the automation capability.
+ *
+ * Responsibilities:
+ *  1. Provider selection via ProviderRegistry + ChainAssetPriorityPolicy
+ *  2. Idempotency: state-mutating calls are cached in Redis for 24h keyed by x-idempotency-key
+ *  3. Ownership validation: ensures the requesting user can only act on their own resources
+ *  4. CapabilityResponse envelope wrapping (latencyMs, traceId, provider info)
+ *
+ * Callers (route handlers) never catch CapabilityError — that's the HTTP layer's job.
+ */
+
+import {
+  ProviderRegistry,
+  ChainAssetPriorityPolicy,
+  CapabilityError,
+  buildSuccess,
+  buildError,
+  type CapabilityRequest,
+  type CapabilityResponse,
+  type ProviderInfo,
+} from '@panorama/capability';
+
+import type { IDCAProvider } from '../../domain/ports/dca.provider.port';
+import type {
+  CreateAccountReq,
+  CreateStrategyReq,
+  SignAndExecuteReq,
+  ValidatePermissionsReq,
+  WithdrawReq,
+} from '../../domain/ports/dca.provider.port';
+import { redisIdempotency } from '../../infrastructure/redis/redis.client';
+
+// ─── DI container shape ───────────────────────────────────────────────────────
+
+export interface DCACapabilityServiceDeps {
+  registry: ProviderRegistry<IDCAProvider>;
+  policy: ChainAssetPriorityPolicy;
+}
+
+// ─── Service ──────────────────────────────────────────────────────────────────
+
+export class DCACapabilityService {
+  private readonly registry: ProviderRegistry<IDCAProvider>;
+  private readonly policy: ChainAssetPriorityPolicy;
+
+  constructor(deps: DCACapabilityServiceDeps) {
+    this.registry = deps.registry;
+    this.policy = deps.policy;
+  }
+
+  // ── Smart account endpoints ────────────────────────────────────────────────
+
+  async createAccount(
+    req: CapabilityRequest<CreateAccountReq>,
+  ): Promise<CapabilityResponse<unknown>> {
+    return this.execute(req, 'create-account', true, async (provider) => {
+      // Users may only create accounts for themselves
+      this.assertSelf(req.userAddress, req.payload.userId, 'create account for');
+      return provider.createAccount(req.payload);
+    });
+  }
+
+  async getAccount(
+    req: CapabilityRequest<{ address: string }>,
+  ): Promise<CapabilityResponse<unknown>> {
+    return this.execute(req, 'get-account', false, async (provider) => {
+      const account = await provider.getAccount(req.payload.address);
+      if (!account) {
+        throw CapabilityError.validation({
+          capability: 'automation',
+          message: 'Smart account not found',
+        });
+      }
+      this.assertSelf(req.userAddress, account.userId, 'access');
+      return account;
+    });
+  }
+
+  async getUserAccounts(
+    req: CapabilityRequest<{ userId: string }>,
+  ): Promise<CapabilityResponse<unknown>> {
+    return this.execute(req, 'get-user-accounts', false, async (provider) => {
+      this.assertSelf(req.userAddress, req.payload.userId, 'list accounts for');
+      const accounts = await provider.getUserAccounts(req.payload.userId);
+      return { accounts };
+    });
+  }
+
+  // ── Strategy endpoints ─────────────────────────────────────────────────────
+
+  async createStrategy(
+    req: CapabilityRequest<CreateStrategyReq>,
+  ): Promise<CapabilityResponse<unknown>> {
+    return this.execute(req, 'create-strategy', true, async (provider) => {
+      // Ownership check: for smart account path, verify the account belongs to this user
+      if (req.payload.smartAccountId) {
+        const account = await provider.getAccount(req.payload.smartAccountId);
+        if (!account) {
+          throw CapabilityError.validation({ capability: 'automation', message: 'Smart account not found' });
+        }
+        this.assertSelf(req.userAddress, account.userId, 'create strategy for');
+      }
+      return provider.createStrategy(req.payload);
+    });
+  }
+
+  async getStrategies(
+    req: CapabilityRequest<{ smartAccountId: string }>,
+  ): Promise<CapabilityResponse<unknown>> {
+    return this.execute(req, 'get-strategies', false, async (provider) => {
+      const account = await provider.getAccount(req.payload.smartAccountId);
+      if (!account) {
+        throw CapabilityError.validation({ capability: 'automation', message: 'Smart account not found' });
+      }
+      this.assertSelf(req.userAddress, account.userId, 'access strategies of');
+      return provider.getStrategies(req.payload.smartAccountId);
+    });
+  }
+
+  async toggleStrategy(
+    req: CapabilityRequest<{ strategyId: string; isActive: boolean }>,
+  ): Promise<CapabilityResponse<unknown>> {
+    return this.execute(req, 'toggle-strategy', true, async (provider) => {
+      await this.assertStrategyOwnership(provider, req.payload.strategyId, req.userAddress);
+      await provider.toggleStrategy(req.payload.strategyId, req.payload.isActive);
+      return { success: true, isActive: req.payload.isActive };
+    });
+  }
+
+  async deleteStrategy(
+    req: CapabilityRequest<{ strategyId: string }>,
+  ): Promise<CapabilityResponse<unknown>> {
+    return this.execute(req, 'delete-strategy', true, async (provider) => {
+      await this.assertStrategyOwnership(provider, req.payload.strategyId, req.userAddress);
+      await provider.deleteStrategy(req.payload.strategyId);
+      return { success: true };
+    });
+  }
+
+  async getHistory(
+    req: CapabilityRequest<{ smartAccountId: string; limit?: number }>,
+  ): Promise<CapabilityResponse<unknown>> {
+    return this.execute(req, 'get-history', false, async (provider) => {
+      const account = await provider.getAccount(req.payload.smartAccountId);
+      if (!account) {
+        throw CapabilityError.validation({ capability: 'automation', message: 'Smart account not found' });
+      }
+      this.assertSelf(req.userAddress, account.userId, 'access history of');
+      return provider.getHistory(req.payload.smartAccountId, req.payload.limit);
+    });
+  }
+
+  // ── Transaction endpoints ──────────────────────────────────────────────────
+
+  async signAndExecute(
+    req: CapabilityRequest<SignAndExecuteReq>,
+  ): Promise<CapabilityResponse<unknown>> {
+    return this.execute(req, 'sign-and-execute', true, async (provider) => {
+      this.assertSelf(req.userAddress, req.payload.userId, 'sign transaction for');
+      return provider.signAndExecute(req.payload);
+    });
+  }
+
+  async validatePermissions(
+    req: CapabilityRequest<ValidatePermissionsReq>,
+  ): Promise<CapabilityResponse<unknown>> {
+    return this.execute(req, 'validate-permissions', false, async (provider) => {
+      return provider.validatePermissions(req.payload);
+    });
+  }
+
+  async withdraw(
+    req: CapabilityRequest<WithdrawReq>,
+  ): Promise<CapabilityResponse<unknown>> {
+    return this.execute(req, 'withdraw', true, async (provider) => {
+      this.assertSelf(req.userAddress, req.payload.userId, 'withdraw from');
+      return provider.withdraw(req.payload);
+    });
+  }
+
+  // ── Core execute helper ────────────────────────────────────────────────────
+
+  /**
+   * Selects the best provider for the request, applies idempotency for mutating operations,
+   * and wraps the result in the standard CapabilityResponse envelope.
+   */
+  private async execute<TData>(
+    req: CapabilityRequest<unknown>,
+    action: string,
+    mutating: boolean,
+    fn: (provider: IDCAProvider) => Promise<TData>,
+  ): Promise<CapabilityResponse<TData>> {
+    const start = Date.now();
+
+    // ── Idempotency check (mutating calls only) ─────────────────────────────
+    if (mutating && req.idempotencyKey) {
+      const cached = await redisIdempotency.get(req.idempotencyKey);
+      if (cached) {
+        return cached as CapabilityResponse<TData>;
+      }
+    }
+
+    // ── Provider selection ──────────────────────────────────────────────────
+    const candidates = this.registry.listByChain(req.chainId);
+    if (candidates.length === 0) {
+      const err = CapabilityError.unsupportedRoute({
+        capability: 'automation',
+        chainId: req.chainId,
+        attempted: [],
+      });
+      return buildError({ error: err, traceId: req.traceId, latencyMs: Date.now() - start });
+    }
+
+    const ranked = this.policy.rank(candidates, { chainId: req.chainId });
+    const provider = ranked[0]!; // Single provider today; fallback loop future work
+    const providerInfo: ProviderInfo = { name: provider.name };
+
+    try {
+      const data = await fn(provider);
+      const latencyMs = Date.now() - start;
+      const response = buildSuccess({ data, provider: providerInfo, traceId: req.traceId, latencyMs });
+
+      // Cache successful mutating responses
+      if (mutating && req.idempotencyKey) {
+        await redisIdempotency.set(req.idempotencyKey, response);
+      }
+
+      return response;
+    } catch (err) {
+      const latencyMs = Date.now() - start;
+      if (CapabilityError.is(err)) {
+        return buildError({ error: err, traceId: req.traceId, latencyMs, provider: providerInfo });
+      }
+      const wrapped = CapabilityError.internal(`Unexpected error in ${action}: ${asMessage(err)}`, err);
+      return buildError({ error: wrapped, traceId: req.traceId, latencyMs, provider: providerInfo });
+    }
+  }
+
+  // ── Ownership helpers ──────────────────────────────────────────────────────
+
+  private assertSelf(requestingUserId: string, resourceOwnerId: string, action: string): void {
+    if (requestingUserId !== resourceOwnerId) {
+      throw CapabilityError.validation({
+        capability: 'automation',
+        message: `Forbidden: you cannot ${action} another user's resources`,
+      });
+    }
+  }
+
+  private async assertStrategyOwnership(
+    provider: IDCAProvider,
+    strategyId: string,
+    requestingUserId: string,
+  ): Promise<void> {
+    // We need the strategy's smartAccountId; DCAService is accessible via the adapter.
+    // The canonical approach: call the provider which has DCAService internally.
+    // We expose a lightweight helper by calling getStrategies indirectly via the DB.
+    // For now, use a direct import of DCAService to resolve the strategy owner.
+    const { DCAService } = await import('../../services/dca.service');
+    const dcaService = new DCAService();
+    const strategy = await dcaService.getStrategy(strategyId);
+    if (!strategy) {
+      throw CapabilityError.validation({ capability: 'automation', message: 'Strategy not found' });
+    }
+    const account = await provider.getAccount(strategy.smartAccountId);
+    if (!account) {
+      throw CapabilityError.validation({ capability: 'automation', message: 'Smart account not found' });
+    }
+    this.assertSelf(requestingUserId, account.userId, 'modify strategy of');
+  }
+}
+
+function asMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  return '<unknown>';
+}

--- a/dca-service/src/domain/ports/dca.provider.port.ts
+++ b/dca-service/src/domain/ports/dca.provider.port.ts
@@ -1,0 +1,187 @@
+/**
+ * DCA Capability Port — domain contract for ERC-4337 automation providers.
+ *
+ * Every automation adapter (ERC4337, future custodial, etc.) implements IDCAProvider.
+ * The capability slug is "automation" (CAPABILITY_SLUGS), matching the sprint naming.
+ *
+ * Invariant: session keys NEVER appear in method return types. Any method that internally
+ * retrieves a session key must consume it and return only on-chain artifacts (tx hashes, addresses).
+ */
+
+import type { ICapabilityProvider, ProviderHealth } from '@panorama/capability';
+
+// ─── Domain types ─────────────────────────────────────────────────────────────
+
+export interface SmartAccountPermissions {
+  approvedTargets: string[];
+  nativeTokenLimitPerTransaction: string;
+  startTimestamp: number;
+  endTimestamp: number;
+}
+
+export interface SmartAccount {
+  address: string;
+  userId: string;
+  name: string;
+  createdAt: number;
+  sessionKeyAddress: string;
+  expiresAt: number;
+  permissions: SmartAccountPermissions;
+}
+
+export interface DCAStrategyRecord {
+  strategyId: string;
+  smartAccountId: string;
+  fromToken: string;
+  toToken: string;
+  fromChainId: number;
+  toChainId: number;
+  amount: string;
+  interval: 'daily' | 'weekly' | 'monthly';
+  lastExecuted: number;
+  nextExecution: number;
+  isActive: boolean;
+}
+
+export interface ExecutionHistoryEntry {
+  timestamp: number;
+  txHash: string;
+  amount: string;
+  fromToken: string;
+  toToken: string;
+  status: 'success' | 'failed';
+  error?: string;
+}
+
+// ─── Request types ────────────────────────────────────────────────────────────
+
+export interface CreateAccountReq {
+  userId: string;
+  name: string;
+  permissions: {
+    approvedTargets: string[];
+    nativeTokenLimit: string;
+    durationDays: number;
+  };
+}
+
+export interface CreateStrategyReq {
+  /** Required for non-Base chains (smart account DCA). */
+  smartAccountId?: string;
+  /** Required for Base chain (DCAVault, non-custodial). */
+  userAddress?: string;
+  /** Optional upfront deposit amount for DCAVault orders. */
+  depositAmount?: string;
+  fromToken: string;
+  toToken: string;
+  fromChainId: number;
+  toChainId: number;
+  amount: string;
+  interval: 'daily' | 'weekly' | 'monthly';
+}
+
+export interface SignAndExecuteReq {
+  smartAccountAddress: string;
+  userId: string;
+  to: string;
+  /** Amount in native token units (e.g. ETH). */
+  value: string;
+  chainId: number;
+  data?: string;
+}
+
+export interface ValidatePermissionsReq {
+  smartAccountAddress: string;
+  to: string;
+  value: string;
+}
+
+export interface WithdrawReq {
+  smartAccountAddress: string;
+  userId: string;
+  tokenAddress: string;
+  amount: string;
+  decimals?: number;
+  chainId: number;
+}
+
+export interface SupportsRouteParams {
+  fromChainId: number;
+  toChainId: number;
+  fromToken?: string;
+  toToken?: string;
+}
+
+// ─── Result types ─────────────────────────────────────────────────────────────
+
+export interface CreateAccountResult {
+  smartAccountAddress: string;
+  sessionKeyAddress: string;
+  expiresAt: Date;
+}
+
+/** Discriminated union: direct DB strategy vs unsigned vault bundle. */
+export type CreateStrategyResult =
+  | {
+      type: 'created';
+      strategyId: string;
+      nextExecution: Date;
+    }
+  | {
+      type: 'vault_unsigned';
+      steps: unknown[];
+      description: string;
+      metadata: unknown;
+    };
+
+export interface GetStrategiesResult {
+  strategies: DCAStrategyRecord[];
+  vaultOrders: unknown[];
+}
+
+export interface GetHistoryResult {
+  history: ExecutionHistoryEntry[];
+  vaultHistory: unknown[];
+}
+
+export interface TransactionResult {
+  transactionHash: string;
+}
+
+export interface ValidationResult {
+  valid: boolean;
+  reason?: string;
+}
+
+// ─── Provider port ────────────────────────────────────────────────────────────
+
+/**
+ * IDCAProvider — capability port for all DCA / automation adapters.
+ *
+ * Extends ICapabilityProvider, which mandates:
+ *   - `readonly name: string`
+ *   - `readonly metadata: ProviderMetadata` (capability: "automation")
+ *   - optional `healthCheck(): Promise<ProviderHealth>`
+ */
+export interface IDCAProvider extends ICapabilityProvider {
+  // ── Smart account lifecycle ──────────────────────────────────────────────────
+  createAccount(req: CreateAccountReq): Promise<CreateAccountResult>;
+  getAccount(address: string): Promise<SmartAccount | null>;
+  getUserAccounts(userId: string): Promise<SmartAccount[]>;
+
+  // ── Strategy management ──────────────────────────────────────────────────────
+  createStrategy(req: CreateStrategyReq): Promise<CreateStrategyResult>;
+  getStrategies(smartAccountId: string): Promise<GetStrategiesResult>;
+  toggleStrategy(id: string, active: boolean): Promise<void>;
+  deleteStrategy(id: string): Promise<void>;
+  getHistory(smartAccountId: string, limit?: number): Promise<GetHistoryResult>;
+
+  // ── Transaction execution ────────────────────────────────────────────────────
+  signAndExecute(req: SignAndExecuteReq): Promise<TransactionResult>;
+  validatePermissions(req: ValidatePermissionsReq): Promise<ValidationResult>;
+  withdraw(req: WithdrawReq): Promise<TransactionResult>;
+
+  // ── Routing & health ─────────────────────────────────────────────────────────
+  supportsRoute(params: SupportsRouteParams): Promise<boolean>;
+  healthCheck(): Promise<ProviderHealth>;
+}

--- a/dca-service/src/index.ts
+++ b/dca-service/src/index.ts
@@ -5,6 +5,11 @@ import { DatabaseService } from './services/database.service';
 import { dcaRoutes } from './routes/dca.routes';
 import { createTransactionRoutes } from './routes/transaction.routes';
 import { vaultDcaRoutes } from './routes/vault.dca.routes';
+import {
+  createCapabilityRouter,
+  createLegacyCapabilityShim,
+  createLegacyTransactionShim,
+} from './infrastructure/http/routes/capability.router';
 import { startDCAExecutor } from './jobs/dca.executor';
 import { AuditLogger } from './services/auditLog.service';
 import {
@@ -116,11 +121,15 @@ async function initializeDatabase() {
     const auditLogger = AuditLogger.getInstance();
     console.log('[DCA Service] ✅ Audit Logger initialized');
 
-    // Register routes
-    app.use('/dca', dcaRoutes());
+    // v1 capability routes (new)
+    app.use('/v1/capability', createCapabilityRouter());
+    console.log('[DCA Service] ✅ Capability routes registered: /v1/capability/dca/* + /v1/capability/_discovery');
+
+    // Legacy routes (deprecated) — kept for backwards compatibility with Deprecation + Sunset headers
+    app.use('/dca', createLegacyCapabilityShim());
     app.use('/dca/vault', vaultDcaRoutes());
-    app.use('/transaction', createTransactionRoutes());
-    console.log('[DCA Service] ✅ Routes registered');
+    app.use('/transaction', createLegacyTransactionShim());
+    console.log('[DCA Service] ✅ Legacy routes registered with Deprecation headers');
 
     // 404 handler - MUST be after all routes
     app.use((req, res) => {

--- a/dca-service/src/infrastructure/adapters/erc4337.dca.adapter.ts
+++ b/dca-service/src/infrastructure/adapters/erc4337.dca.adapter.ts
@@ -1,0 +1,429 @@
+/**
+ * ERC4337DCAAdapter — Automation capability backed by ERC-4337 smart accounts (Thirdweb).
+ *
+ * SECURITY INVARIANT: session keys are fetched internally for on-chain signing and are
+ * NEVER included in any return value. Only on-chain artifacts (addresses, tx hashes) leave
+ * this adapter. Violating this invariant would expose custody to the caller.
+ *
+ * Wraps:
+ *   - SmartAccountService (account lifecycle + session key store)
+ *   - DCAService          (strategy CRUD + execution history, PostgreSQL)
+ *   - TransactionService  (sign-and-execute via session key)
+ *   - Execution layer     (DCAVault proxy for Base chain, via HTTP)
+ */
+
+import type {
+  ProviderMetadata,
+  ProviderHealth,
+} from '@panorama/capability';
+import { CapabilityError } from '@panorama/capability';
+
+import { SmartAccountService } from '../../services/smartAccount.service';
+import { DCAService } from '../../services/dca.service';
+import { TransactionService } from '../../services/transaction.service';
+import { DatabaseService } from '../../services/database.service';
+
+import type {
+  IDCAProvider,
+  CreateAccountReq,
+  CreateAccountResult,
+  CreateStrategyReq,
+  CreateStrategyResult,
+  ExecutionHistoryEntry,
+  GetHistoryResult,
+  GetStrategiesResult,
+  SignAndExecuteReq,
+  SmartAccount,
+  SupportsRouteParams,
+  TransactionResult,
+  ValidatePermissionsReq,
+  ValidationResult,
+  WithdrawReq,
+} from '../../domain/ports/dca.provider.port';
+
+// EVM chains supported by Uniswap V3 smart account DCA
+const SMART_ACCOUNT_CHAINS = new Set([1, 5, 137, 42161, 10, 8453]);
+
+// Chains where DCAVault (non-custodial, execution layer) is available
+const VAULT_CHAINS = new Set([8453]);
+
+// Token decimals for Base chain — used for wei conversion in vault orders
+const BASE_TOKEN_DECIMALS: Record<string, number> = {
+  '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913': 6,  // USDC
+  '0x4200000000000000000000000000000000000006': 18, // WETH
+  '0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf': 8,  // cbBTC
+  '0x940181a94a35a4569e4529a3cdfb74e38fd98631': 18, // AERO
+  '0x50c5725949a6f0c72e6c4a641f24049a917db0cb': 18, // DAI
+};
+
+const INTERVAL_SECONDS: Record<string, number> = {
+  daily: 86400,
+  weekly: 604800,
+  monthly: 2592000,
+};
+
+export class ERC4337DCAAdapter implements IDCAProvider {
+  readonly name = 'erc4337-dca';
+
+  readonly metadata: ProviderMetadata = {
+    name: 'erc4337-dca',
+    capability: 'automation',
+    supportedChains: [...SMART_ACCOUNT_CHAINS],
+    features: ['smart-account', 'session-key', 'dca-vault', 'erc4337'],
+    version: '1.0.0',
+    enabled: true,
+  };
+
+  private readonly smartAccountService: SmartAccountService;
+  private readonly dcaService: DCAService;
+  private readonly transactionService: TransactionService;
+  private readonly executionLayerUrl: string;
+
+  constructor() {
+    this.smartAccountService = new SmartAccountService();
+    this.dcaService = new DCAService();
+    this.transactionService = new TransactionService(this.smartAccountService);
+    this.executionLayerUrl = process.env.EXECUTION_LAYER_URL || 'http://localhost:3010';
+  }
+
+  // ── Smart account lifecycle ────────────────────────────────────────────────
+
+  async createAccount(req: CreateAccountReq): Promise<CreateAccountResult> {
+    try {
+      return await this.smartAccountService.createSmartAccount(req);
+    } catch (err) {
+      throw CapabilityError.providerFailure({
+        capability: 'automation',
+        provider: this.name,
+        message: `Failed to create smart account: ${asMessage(err)}`,
+        cause: err,
+      });
+    }
+  }
+
+  async getAccount(address: string): Promise<SmartAccount | null> {
+    try {
+      return await this.smartAccountService.getSmartAccount(address);
+    } catch (err) {
+      throw CapabilityError.providerFailure({
+        capability: 'automation',
+        provider: this.name,
+        message: `Failed to fetch smart account: ${asMessage(err)}`,
+        cause: err,
+      });
+    }
+  }
+
+  async getUserAccounts(userId: string): Promise<SmartAccount[]> {
+    try {
+      return await this.smartAccountService.getUserAccounts(userId);
+    } catch (err) {
+      throw CapabilityError.providerFailure({
+        capability: 'automation',
+        provider: this.name,
+        message: `Failed to fetch user accounts: ${asMessage(err)}`,
+        cause: err,
+      });
+    }
+  }
+
+  // ── Strategy management ────────────────────────────────────────────────────
+
+  async createStrategy(req: CreateStrategyReq): Promise<CreateStrategyResult> {
+    try {
+      // Base chain → DCAVault (non-custodial, unsigned tx bundle returned to frontend)
+      if (VAULT_CHAINS.has(req.fromChainId)) {
+        const walletAddress = req.smartAccountId || req.userAddress;
+        if (!walletAddress) {
+          throw CapabilityError.validation({
+            capability: 'automation',
+            message: 'userAddress or smartAccountId required for Base DCA vault',
+          });
+        }
+        return await this.proxyVaultCreate({ ...req, userAddress: walletAddress });
+      }
+
+      // Other chains → smart account + DB strategy
+      if (!req.smartAccountId) {
+        throw CapabilityError.validation({
+          capability: 'automation',
+          message: 'smartAccountId required for non-Base chain DCA',
+        });
+      }
+
+      const result = await this.dcaService.createStrategy(req as any);
+      return { type: 'created', ...result };
+    } catch (err) {
+      if (CapabilityError.is(err)) throw err;
+      throw CapabilityError.providerFailure({
+        capability: 'automation',
+        provider: this.name,
+        message: `Failed to create strategy: ${asMessage(err)}`,
+        cause: err,
+      });
+    }
+  }
+
+  async getStrategies(smartAccountId: string): Promise<GetStrategiesResult> {
+    try {
+      const account = await this.smartAccountService.getSmartAccount(smartAccountId);
+      const [rawStrategies, vaultOrders] = await Promise.all([
+        this.dcaService.getAccountStrategies(smartAccountId),
+        account ? this.fetchVaultOrders(account.address) : Promise.resolve([]),
+      ]);
+      // Normalise: legacy DCAStrategy has strategyId?: string; port requires string
+      const strategies = rawStrategies.map((s) => ({ ...s, strategyId: s.strategyId ?? '' }));
+      return { strategies, vaultOrders };
+    } catch (err) {
+      if (CapabilityError.is(err)) throw err;
+      throw CapabilityError.providerFailure({
+        capability: 'automation',
+        provider: this.name,
+        message: `Failed to fetch strategies: ${asMessage(err)}`,
+        cause: err,
+      });
+    }
+  }
+
+  async toggleStrategy(id: string, active: boolean): Promise<void> {
+    try {
+      await this.dcaService.toggleStrategy(id, active);
+    } catch (err) {
+      throw CapabilityError.providerFailure({
+        capability: 'automation',
+        provider: this.name,
+        message: `Failed to toggle strategy: ${asMessage(err)}`,
+        cause: err,
+      });
+    }
+  }
+
+  async deleteStrategy(id: string): Promise<void> {
+    try {
+      await this.dcaService.deleteStrategy(id);
+    } catch (err) {
+      throw CapabilityError.providerFailure({
+        capability: 'automation',
+        provider: this.name,
+        message: `Failed to delete strategy: ${asMessage(err)}`,
+        cause: err,
+      });
+    }
+  }
+
+  async getHistory(smartAccountId: string, limit = 100): Promise<GetHistoryResult> {
+    try {
+      const account = await this.smartAccountService.getSmartAccount(smartAccountId);
+      const [history, vaultHistory] = await Promise.all([
+        this.dcaService.getExecutionHistory(smartAccountId, limit),
+        account ? this.fetchVaultHistory(account.address) : Promise.resolve([]),
+      ]);
+      return { history, vaultHistory };
+    } catch (err) {
+      if (CapabilityError.is(err)) throw err;
+      throw CapabilityError.providerFailure({
+        capability: 'automation',
+        provider: this.name,
+        message: `Failed to fetch history: ${asMessage(err)}`,
+        cause: err,
+      });
+    }
+  }
+
+  // ── Transaction execution ──────────────────────────────────────────────────
+
+  async signAndExecute(req: SignAndExecuteReq): Promise<TransactionResult> {
+    try {
+      const result = await this.transactionService.signAndExecuteTransaction(req);
+      if (!result.success) {
+        throw new Error(result.error || 'Transaction failed');
+      }
+      return { transactionHash: result.transactionHash };
+    } catch (err) {
+      if (CapabilityError.is(err)) throw err;
+      throw CapabilityError.providerFailure({
+        capability: 'automation',
+        provider: this.name,
+        message: `sign-and-execute failed: ${asMessage(err)}`,
+        cause: err,
+      });
+    }
+  }
+
+  async validatePermissions(req: ValidatePermissionsReq): Promise<ValidationResult> {
+    try {
+      return await this.transactionService.validateSessionPermissions(
+        req.smartAccountAddress,
+        req.to,
+        req.value,
+      );
+    } catch (err) {
+      throw CapabilityError.providerFailure({
+        capability: 'automation',
+        provider: this.name,
+        message: `Permission validation failed: ${asMessage(err)}`,
+        cause: err,
+      });
+    }
+  }
+
+  /**
+   * Withdraw ERC20 tokens from a smart account to the owner's EOA.
+   * SECURITY INVARIANT: session key is retrieved internally and never returned.
+   */
+  async withdraw(req: WithdrawReq): Promise<TransactionResult> {
+    try {
+      const { createThirdwebClient, getContract, prepareContractCall, sendTransaction } =
+        await import('thirdweb');
+      const { defineChain } = await import('thirdweb/chains');
+      const { privateKeyToAccount, smartWallet } = await import('thirdweb/wallets');
+
+      const client = createThirdwebClient({ secretKey: process.env.THIRDWEB_SECRET_KEY! });
+
+      // INVARIANT: session key fetched server-side, never returned to caller
+      const sessionKeyPrivateKey = await this.smartAccountService.getSessionKey(
+        req.smartAccountAddress,
+      );
+      if (!sessionKeyPrivateKey) {
+        throw CapabilityError.validation({
+          capability: 'automation',
+          message: 'Session key not found or expired for this smart account',
+        });
+      }
+
+      const personalAccount = privateKeyToAccount({ client, privateKey: sessionKeyPrivateKey });
+      const chain = defineChain(req.chainId);
+      const wallet = smartWallet({ chain, gasless: false, sponsorGas: false });
+      const smartAccount = await wallet.connect({ client, personalAccount });
+
+      const tokenContract = getContract({ client, chain, address: req.tokenAddress });
+      const decimals = req.decimals ?? 18;
+
+      // Safe BigInt conversion avoiding floating-point precision loss
+      const amountInUnits = toTokenUnits(req.amount, decimals);
+
+      const transaction = prepareContractCall({
+        contract: tokenContract,
+        method: 'function transfer(address to, uint256 amount) returns (bool)',
+        params: [req.userId, amountInUnits],
+      });
+
+      const result = await sendTransaction({ transaction, account: smartAccount });
+      return { transactionHash: result.transactionHash };
+    } catch (err) {
+      if (CapabilityError.is(err)) throw err;
+      throw CapabilityError.providerFailure({
+        capability: 'automation',
+        provider: this.name,
+        message: `Withdrawal failed: ${asMessage(err)}`,
+        cause: err,
+      });
+    }
+  }
+
+  // ── Routing & health ───────────────────────────────────────────────────────
+
+  async supportsRoute(params: SupportsRouteParams): Promise<boolean> {
+    // DCAVault handles same-chain Base routes; smart account handles all SMART_ACCOUNT_CHAINS
+    if (!SMART_ACCOUNT_CHAINS.has(params.fromChainId)) return false;
+    // Cross-chain DCA not supported yet (fromChainId must equal toChainId for smart-account path)
+    if (params.toChainId && params.fromChainId !== params.toChainId) return false;
+    return true;
+  }
+
+  async healthCheck(): Promise<ProviderHealth> {
+    const start = Date.now();
+    try {
+      const db = DatabaseService.getInstance();
+      const ok = await db.checkConnection();
+      const latencyMs = Date.now() - start;
+      if (!ok) {
+        return { healthy: false, latencyMs, reason: 'DB connection failed', checkedAt: new Date().toISOString() };
+      }
+      return { healthy: true, latencyMs, checkedAt: new Date().toISOString() };
+    } catch (err) {
+      return {
+        healthy: false,
+        latencyMs: Date.now() - start,
+        reason: asMessage(err),
+        checkedAt: new Date().toISOString(),
+      };
+    }
+  }
+
+  // ── Private helpers ────────────────────────────────────────────────────────
+
+  private async proxyVaultCreate(
+    req: CreateStrategyReq & { userAddress: string },
+  ): Promise<CreateStrategyResult> {
+    const intervalSeconds = INTERVAL_SECONDS[req.interval] ?? 86400;
+    const amountWei = toTokenUnits(req.amount, BASE_TOKEN_DECIMALS[req.fromToken.toLowerCase()] ?? 18);
+    const depositWei = req.depositAmount
+      ? toTokenUnits(req.depositAmount, BASE_TOKEN_DECIMALS[req.fromToken.toLowerCase()] ?? 18)
+      : amountWei;
+
+    const payload = {
+      userAddress: req.userAddress,
+      tokenIn: req.fromToken,
+      tokenOut: req.toToken,
+      amountPerSwap: amountWei.toString(),
+      intervalSeconds,
+      depositAmount: depositWei.toString(),
+    };
+
+    const res = await fetch(`${this.executionLayerUrl}/dca/prepare-create`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+
+    const data = await res.json() as any;
+    if (!res.ok) {
+      throw new Error(data.error || `Execution layer error ${res.status}`);
+    }
+
+    return {
+      type: 'vault_unsigned',
+      steps: data.bundle.steps,
+      description: data.bundle.summary,
+      metadata: data.metadata,
+    };
+  }
+
+  private async fetchVaultOrders(walletAddress: string): Promise<unknown[]> {
+    try {
+      const res = await fetch(`${this.executionLayerUrl}/dca/orders/${walletAddress}`);
+      if (!res.ok) return [];
+      const data = await res.json() as { orders?: unknown[] };
+      return data.orders ?? [];
+    } catch {
+      return [];
+    }
+  }
+
+  private async fetchVaultHistory(walletAddress: string): Promise<unknown[]> {
+    try {
+      const res = await fetch(`${this.executionLayerUrl}/dca/history/${walletAddress}`);
+      if (!res.ok) return [];
+      const data = await res.json() as { transactions?: unknown[] };
+      return data.transactions ?? [];
+    } catch {
+      return [];
+    }
+  }
+}
+
+// ─── Utilities ──────────────────────────────────────────────────────────────
+
+/** Convert a decimal-string amount to token units (BigInt), avoiding floating-point loss. */
+function toTokenUnits(amount: string, decimals: number): bigint {
+  const [intPart = '0', fracPart = ''] = amount.split('.');
+  const fracPadded = fracPart.padEnd(decimals, '0').slice(0, decimals);
+  return BigInt(intPart) * BigInt(10 ** decimals) + BigInt(fracPadded || '0');
+}
+
+function asMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === 'string') return err;
+  return '<unknown error>';
+}

--- a/dca-service/src/infrastructure/di/container.ts
+++ b/dca-service/src/infrastructure/di/container.ts
@@ -1,0 +1,49 @@
+/**
+ * DI Container — wires the automation capability for the dca-service.
+ *
+ * Single source of truth for object creation. Import `container` singleton
+ * everywhere you need a service; do not instantiate services directly in route files.
+ */
+
+import { ProviderRegistry, ChainAssetPriorityPolicy } from '@panorama/capability';
+import { ERC4337DCAAdapter } from '../adapters/erc4337.dca.adapter';
+import { DCACapabilityService } from '../../application/services/dca.capability.service';
+import type { IDCAProvider } from '../../domain/ports/dca.provider.port';
+
+export class DCAContainer {
+  private static _instance: DCAContainer;
+
+  readonly provider: ERC4337DCAAdapter;
+  readonly registry: ProviderRegistry<IDCAProvider>;
+  readonly policy: ChainAssetPriorityPolicy;
+  readonly capabilityService: DCACapabilityService;
+
+  private constructor() {
+    this.provider = new ERC4337DCAAdapter();
+
+    this.registry = new ProviderRegistry<IDCAProvider>();
+    this.registry.register(this.provider);
+
+    this.policy = new ChainAssetPriorityPolicy({
+      '1':     ['erc4337-dca'],
+      '137':   ['erc4337-dca'],
+      '42161': ['erc4337-dca'],
+      '10':    ['erc4337-dca'],
+      '8453':  ['erc4337-dca'],
+    });
+
+    this.capabilityService = new DCACapabilityService({
+      registry: this.registry,
+      policy: this.policy,
+    });
+  }
+
+  static getInstance(): DCAContainer {
+    if (!DCAContainer._instance) {
+      DCAContainer._instance = new DCAContainer();
+    }
+    return DCAContainer._instance;
+  }
+}
+
+export const container = DCAContainer.getInstance();

--- a/dca-service/src/infrastructure/http/routes/capability.router.ts
+++ b/dca-service/src/infrastructure/http/routes/capability.router.ts
@@ -1,0 +1,325 @@
+/**
+ * Capability Router — /v1/capability/dca/* endpoints.
+ *
+ * Mounts:
+ *   POST   /v1/capability/dca/account               createAccount
+ *   GET    /v1/capability/dca/account/:address       getAccount
+ *   GET    /v1/capability/dca/accounts/:userId       getUserAccounts
+ *   POST   /v1/capability/dca/strategy               createStrategy
+ *   GET    /v1/capability/dca/strategies/:accountId  getStrategies
+ *   PATCH  /v1/capability/dca/strategy/:id/toggle    toggleStrategy
+ *   DELETE /v1/capability/dca/strategy/:id           deleteStrategy
+ *   GET    /v1/capability/dca/history/:accountId     getHistory
+ *   POST   /v1/capability/dca/execute                signAndExecute
+ *   POST   /v1/capability/dca/validate               validatePermissions
+ *   POST   /v1/capability/dca/withdraw               withdraw
+ *   GET    /v1/capability/_discovery                 discovery
+ *
+ * Also re-mounts legacy /dca/* and /transaction/* routes with Deprecation + Sunset headers.
+ *
+ * CapabilityRequest.userAddress is always sourced from req.user.id (Telegram auth).
+ * Callers must pass x-trace-id; x-tenant-id defaults to "panorama".
+ * x-idempotency-key is optional for read endpoints, recommended for mutating ones.
+ */
+
+import { Router, type Request, type Response } from 'express';
+import { randomUUID } from 'crypto';
+import {
+  createDiscoveryHandler,
+  ProviderRegistry,
+  ChainAssetPriorityPolicy,
+  CapabilityError,
+  categoryToHttpStatus,
+} from '@panorama/capability';
+import type { CapabilityRequest } from '@panorama/capability';
+
+import { ERC4337DCAAdapter } from '../../adapters/erc4337.dca.adapter';
+import { DCACapabilityService } from '../../../application/services/dca.capability.service';
+import type { IDCAProvider } from '../../../domain/ports/dca.provider.port';
+import {
+  verifyTelegramAuth,
+  devBypassAuth,
+  type AuthenticatedRequest,
+} from '../../../middleware/auth.middleware';
+import {
+  createAccountLimiter,
+  createStrategyLimiter,
+  readLimiter,
+  transactionLimiter,
+  generalLimiter,
+} from '../../../middleware/rateLimit.middleware';
+
+// ─── Bootstrap: registry + policy + service ──────────────────────────────────
+
+const provider = new ERC4337DCAAdapter();
+const registry = new ProviderRegistry<IDCAProvider>();
+registry.register(provider);
+
+const policy = new ChainAssetPriorityPolicy({
+  // ERC-4337 adapter is the only automation provider — priority on all supported chains.
+  '1':     ['erc4337-dca'],
+  '137':   ['erc4337-dca'],
+  '42161': ['erc4337-dca'],
+  '10':    ['erc4337-dca'],
+  '8453':  ['erc4337-dca'],
+});
+
+const svc = new DCACapabilityService({ registry, policy });
+
+const discoveryHandler = createDiscoveryHandler({
+  listProviders: () => registry.listAll(),
+});
+
+// ─── Router factory ───────────────────────────────────────────────────────────
+
+export function createCapabilityRouter(): Router {
+  const router = Router();
+
+  const auth = [devBypassAuth, verifyTelegramAuth];
+
+  // ── Account endpoints ──────────────────────────────────────────────────────
+
+  router.post('/dca/account', createAccountLimiter, ...auth, async (req: AuthenticatedRequest, res: Response) => {
+    const capReq = buildReq(req, req.body);
+    const result = await svc.createAccount(capReq);
+    return sendCapabilityResponse(res, result);
+  });
+
+  router.get('/dca/account/:address', readLimiter, ...auth, async (req: AuthenticatedRequest, res: Response) => {
+    const capReq = buildReq(req, { address: req.params.address });
+    const result = await svc.getAccount(capReq);
+    return sendCapabilityResponse(res, result);
+  });
+
+  router.get('/dca/accounts/:userId', readLimiter, ...auth, async (req: AuthenticatedRequest, res: Response) => {
+    const capReq = buildReq(req, { userId: req.params.userId });
+    const result = await svc.getUserAccounts(capReq);
+    return sendCapabilityResponse(res, result);
+  });
+
+  // ── Strategy endpoints ─────────────────────────────────────────────────────
+
+  router.post('/dca/strategy', createStrategyLimiter, ...auth, async (req: AuthenticatedRequest, res: Response) => {
+    const capReq = buildReq(req, req.body);
+    const result = await svc.createStrategy(capReq);
+    return sendCapabilityResponse(res, result);
+  });
+
+  router.get('/dca/strategies/:accountId', readLimiter, ...auth, async (req: AuthenticatedRequest, res: Response) => {
+    const capReq = buildReq(req, { smartAccountId: req.params.accountId });
+    const result = await svc.getStrategies(capReq);
+    return sendCapabilityResponse(res, result);
+  });
+
+  router.patch('/dca/strategy/:id/toggle', generalLimiter, ...auth, async (req: AuthenticatedRequest, res: Response) => {
+    if (typeof req.body.isActive !== 'boolean') {
+      return res.status(400).json({ error: 'isActive must be a boolean' });
+    }
+    const capReq = buildReq(req, { strategyId: req.params.id, isActive: req.body.isActive });
+    const result = await svc.toggleStrategy(capReq);
+    return sendCapabilityResponse(res, result);
+  });
+
+  router.delete('/dca/strategy/:id', generalLimiter, ...auth, async (req: AuthenticatedRequest, res: Response) => {
+    const capReq = buildReq(req, { strategyId: req.params.id });
+    const result = await svc.deleteStrategy(capReq);
+    return sendCapabilityResponse(res, result);
+  });
+
+  router.get('/dca/history/:accountId', readLimiter, ...auth, async (req: AuthenticatedRequest, res: Response) => {
+    const limit = req.query.limit ? parseInt(req.query.limit as string) : undefined;
+    const capReq = buildReq(req, { smartAccountId: req.params.accountId, limit });
+    const result = await svc.getHistory(capReq);
+    return sendCapabilityResponse(res, result);
+  });
+
+  // ── Transaction endpoints ──────────────────────────────────────────────────
+
+  router.post('/dca/execute', transactionLimiter, ...auth, async (req: AuthenticatedRequest, res: Response) => {
+    const capReq = buildReq(req, req.body);
+    const result = await svc.signAndExecute(capReq);
+    return sendCapabilityResponse(res, result);
+  });
+
+  router.post('/dca/validate', generalLimiter, ...auth, async (req: AuthenticatedRequest, res: Response) => {
+    const capReq = buildReq(req, req.body);
+    const result = await svc.validatePermissions(capReq);
+    return sendCapabilityResponse(res, result);
+  });
+
+  router.post('/dca/withdraw', transactionLimiter, ...auth, async (req: AuthenticatedRequest, res: Response) => {
+    const capReq = buildReq(req, req.body);
+    const result = await svc.withdraw(capReq);
+    return sendCapabilityResponse(res, result);
+  });
+
+  // ── Discovery ──────────────────────────────────────────────────────────────
+
+  router.get('/_discovery', readLimiter, (req: Request, res: Response) => {
+    const traceId = (req.headers['x-trace-id'] as string) || randomUUID();
+    const result = discoveryHandler({ traceId, force: req.query.force === 'true' });
+    res.setHeader('Cache-Control', `public, max-age=${result.data.cacheTtlSeconds}`);
+    return res.status(200).json(result);
+  });
+
+  return router;
+}
+
+// ─── Legacy router (Deprecation + Sunset headers) ────────────────────────────
+
+const DEPRECATION_DATE = 'Sat, 01 Nov 2025 00:00:00 GMT';
+const SUNSET_DATE = 'Mon, 01 Dec 2025 00:00:00 GMT';
+const DEPRECATION_LINK = 'https://docs.panoramablock.com/api/deprecation#dca-v0';
+
+function deprecationHeaders(res: Response): void {
+  res.setHeader('Deprecation', DEPRECATION_DATE);
+  res.setHeader('Sunset', SUNSET_DATE);
+  res.setHeader('Link', `<${DEPRECATION_LINK}>; rel="deprecation"`);
+}
+
+/**
+ * Legacy route shim — proxies old paths to the new capability service and adds
+ * Deprecation + Sunset headers so clients know to migrate.
+ */
+export function createLegacyCapabilityShim(): Router {
+  const router = Router();
+  const auth = [devBypassAuth, verifyTelegramAuth];
+
+  const wrap =
+    (handler: (req: AuthenticatedRequest, res: Response) => Promise<Response | void>) =>
+    async (req: AuthenticatedRequest, res: Response) => {
+      deprecationHeaders(res);
+      return handler(req, res);
+    };
+
+  // /dca/create-account → POST /v1/capability/dca/account
+  router.post('/create-account', createAccountLimiter, ...auth,
+    wrap(async (req, res) => {
+      const capReq = buildReq(req, req.body);
+      return sendCapabilityResponse(res, await svc.createAccount(capReq));
+    }),
+  );
+
+  // /dca/accounts/:userId
+  router.get('/accounts/:userId', readLimiter, ...auth,
+    wrap(async (req, res) => {
+      const capReq = buildReq(req, { userId: req.params.userId });
+      return sendCapabilityResponse(res, await svc.getUserAccounts(capReq));
+    }),
+  );
+
+  // /dca/account/:address
+  router.get('/account/:address', readLimiter, ...auth,
+    wrap(async (req, res) => {
+      const capReq = buildReq(req, { address: req.params.address });
+      return sendCapabilityResponse(res, await svc.getAccount(capReq));
+    }),
+  );
+
+  // /dca/create-strategy
+  router.post('/create-strategy', createStrategyLimiter, ...auth,
+    wrap(async (req, res) => {
+      const capReq = buildReq(req, req.body);
+      return sendCapabilityResponse(res, await svc.createStrategy(capReq));
+    }),
+  );
+
+  // /dca/strategies/:smartAccountId
+  router.get('/strategies/:smartAccountId', readLimiter, ...auth,
+    wrap(async (req, res) => {
+      const capReq = buildReq(req, { smartAccountId: req.params.smartAccountId });
+      return sendCapabilityResponse(res, await svc.getStrategies(capReq));
+    }),
+  );
+
+  // /dca/strategy/:strategyId/toggle
+  router.patch('/strategy/:strategyId/toggle', generalLimiter, ...auth,
+    wrap(async (req, res) => {
+      const capReq = buildReq(req, { strategyId: req.params.strategyId, isActive: req.body.isActive });
+      return sendCapabilityResponse(res, await svc.toggleStrategy(capReq));
+    }),
+  );
+
+  // /dca/strategy/:strategyId (DELETE)
+  router.delete('/strategy/:strategyId', generalLimiter, ...auth,
+    wrap(async (req, res) => {
+      const capReq = buildReq(req, { strategyId: req.params.strategyId });
+      return sendCapabilityResponse(res, await svc.deleteStrategy(capReq));
+    }),
+  );
+
+  // /dca/history/:smartAccountId
+  router.get('/history/:smartAccountId', readLimiter, ...auth,
+    wrap(async (req, res) => {
+      const limit = req.query.limit ? parseInt(req.query.limit as string) : undefined;
+      const capReq = buildReq(req, { smartAccountId: req.params.smartAccountId, limit });
+      return sendCapabilityResponse(res, await svc.getHistory(capReq));
+    }),
+  );
+
+  return router;
+}
+
+/**
+ * Legacy transaction route shim (/transaction/*).
+ */
+export function createLegacyTransactionShim(): Router {
+  const router = Router();
+  const auth = [devBypassAuth, verifyTelegramAuth];
+
+  const wrap =
+    (handler: (req: AuthenticatedRequest, res: Response) => Promise<Response | void>) =>
+    async (req: AuthenticatedRequest, res: Response) => {
+      deprecationHeaders(res);
+      return handler(req, res);
+    };
+
+  // /transaction/sign-and-execute → POST /v1/capability/dca/execute
+  router.post('/sign-and-execute', transactionLimiter, ...auth,
+    wrap(async (req, res) => {
+      const capReq = buildReq(req, req.body);
+      return sendCapabilityResponse(res, await svc.signAndExecute(capReq));
+    }),
+  );
+
+  // /transaction/validate → POST /v1/capability/dca/validate
+  router.post('/validate', generalLimiter, ...auth,
+    wrap(async (req, res) => {
+      const capReq = buildReq(req, req.body);
+      return sendCapabilityResponse(res, await svc.validatePermissions(capReq));
+    }),
+  );
+
+  // /transaction/withdraw-token → POST /v1/capability/dca/withdraw
+  router.post('/withdraw-token', transactionLimiter, ...auth,
+    wrap(async (req, res) => {
+      const capReq = buildReq(req, req.body);
+      return sendCapabilityResponse(res, await svc.withdraw(capReq));
+    }),
+  );
+
+  return router;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function buildReq<T>(req: AuthenticatedRequest, payload: T): CapabilityRequest<T> {
+  return {
+    tenantId: (req.headers['x-tenant-id'] as string) || 'panorama',
+    traceId: (req.headers['x-trace-id'] as string) || randomUUID(),
+    idempotencyKey: req.headers['x-idempotency-key'] as string | undefined,
+    // chainId from body, query, or default to Base (8453)
+    chainId: parseInt((req.body?.chainId ?? req.body?.fromChainId ?? req.query.chainId ?? '8453') as string),
+    userAddress: req.user?.id ?? '',
+    payload,
+    receivedAt: new Date().toISOString(),
+  };
+}
+
+function sendCapabilityResponse(res: Response, result: { status: string; error?: any }): Response {
+  if (result.status === 'error') {
+    const httpStatus = (result.error as any)?.httpStatus ?? 500;
+    return res.status(httpStatus).json(result);
+  }
+  return res.status(200).json(result);
+}

--- a/dca-service/src/infrastructure/redis/redis.client.ts
+++ b/dca-service/src/infrastructure/redis/redis.client.ts
@@ -1,0 +1,76 @@
+/**
+ * Redis client singleton for idempotency storage.
+ * Connection is lazy — the client connects on first use and reconnects automatically.
+ * All public methods are safe to call even if Redis is unavailable (they fail open).
+ */
+
+import { createClient, type RedisClientType } from 'redis';
+
+const IDEMPOTENCY_TTL_SECONDS = 86400; // 24 h
+
+class RedisIdempotencyClient {
+  private client: RedisClientType | null = null;
+  private connected = false;
+
+  private async getClient(): Promise<RedisClientType | null> {
+    if (this.connected && this.client) return this.client;
+
+    try {
+      const url = buildRedisUrl();
+      this.client = createClient({ url }) as RedisClientType;
+
+      this.client.on('error', (err) => {
+        console.warn('[RedisIdempotency] client error:', err.message);
+        this.connected = false;
+      });
+
+      await this.client.connect();
+      this.connected = true;
+      console.log('[RedisIdempotency] Connected');
+      return this.client;
+    } catch (err: any) {
+      console.warn('[RedisIdempotency] Could not connect — idempotency disabled:', err.message);
+      this.connected = false;
+      this.client = null;
+      return null;
+    }
+  }
+
+  async get(key: string): Promise<unknown | null> {
+    try {
+      const c = await this.getClient();
+      if (!c) return null;
+      const raw = await c.get(prefixed(key));
+      if (!raw) return null;
+      return JSON.parse(raw);
+    } catch {
+      return null;
+    }
+  }
+
+  async set(key: string, value: unknown): Promise<void> {
+    try {
+      const c = await this.getClient();
+      if (!c) return;
+      await c.set(prefixed(key), JSON.stringify(value), { EX: IDEMPOTENCY_TTL_SECONDS });
+    } catch (err: any) {
+      console.warn('[RedisIdempotency] set failed:', err.message);
+    }
+  }
+}
+
+function prefixed(key: string): string {
+  return `idempotency:dca:${key}`;
+}
+
+function buildRedisUrl(): string {
+  const host = process.env.REDIS_HOST || 'localhost';
+  const port = process.env.REDIS_PORT || '6379';
+  const pass = process.env.REDIS_PASS;
+  const tls = process.env.REDIS_TLS === 'true';
+  const scheme = tls ? 'rediss' : 'redis';
+  if (pass) return `${scheme}://:${pass}@${host}:${port}`;
+  return `${scheme}://${host}:${port}`;
+}
+
+export const redisIdempotency = new RedisIdempotencyClient();

--- a/dca-service/tsconfig.json
+++ b/dca-service/tsconfig.json
@@ -4,7 +4,6 @@
     "module": "commonjs",
     "lib": ["ES2020"],
     "outDir": "./dist",
-    "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
@@ -13,8 +12,20 @@
     "moduleResolution": "node",
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "baseUrl": "./",
+    "paths": {
+      "@panorama/capability": ["../shared/capability/index.ts"],
+      "@panorama/capability/*": ["../shared/capability/*"]
+    }
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": [
+    "node_modules",
+    "dist",
+    "../shared/capability/node_modules",
+    "../shared/capability/__tests__",
+    "../shared/capability/chains/__tests__",
+    "../shared/capability/http/__tests__"
+  ]
 }

--- a/lending-service/index.js
+++ b/lending-service/index.js
@@ -233,6 +233,21 @@ app.use('/validation-swap', validationSwapRoutes);
 app.use('/benqi', benqiRoutes);
 app.use('/benqi-validation', benqiValidationRoutes);
 
+// Capability routes (/v1/capability/lend/* and /v1/capability/_discovery)
+// Built from TypeScript via `npm run build` — loaded at runtime from dist/
+try {
+  const { buildLendingContainer } = require('./dist/infrastructure/di/container');
+  const { createCapabilityRouter } = require('./dist/infrastructure/http/routes/capability.router');
+  const container = buildLendingContainer();
+  container.start();
+  app.use('/v1/capability', createCapabilityRouter(container.facade, container.discoveryHandler));
+  console.log('✅ Capability routes mounted at /v1/capability/lend/*');
+  process.on('SIGTERM', () => container.stop());
+  process.on('SIGINT', () => container.stop());
+} catch (err) {
+  console.warn('⚠️  Capability layer not loaded (run `npm run build` first):', err.message);
+}
+
 // Middleware de tratamento de erros
 app.use((err, req, res, next) => {
   console.error('Unhandled error:', err);

--- a/lending-service/package.json
+++ b/lending-service/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "node index.js",
     "dev": "nodemon index.js",
+    "build": "tsc -p tsconfig.json",
     "test": "jest --config jest.config.js",
     "test:unit": "jest --config jest.config.js",
     "test:validation": "node test-validation.js",
@@ -29,13 +30,19 @@
     "ethers": "^6.15.0",
     "express-rate-limit": "^7.1.5",
     "helmet": "^7.1.0",
-    "morgan": "^1.10.0"
+    "morgan": "^1.10.0",
+    "uuid": "^9.0.1",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/uuid": "^9.0.7",
+    "@types/express": "^4.17.21",
     "eslint": "^8.56.0",
     "express": "^5.2.1",
     "jest": "^29.7.0",
     "nodemon": "^3.1.10",
-    "supertest": "^7.1.4"
+    "supertest": "^7.1.4",
+    "typescript": "^5.3.3"
   }
 }

--- a/lending-service/src/application/services/lending.capability.service.ts
+++ b/lending-service/src/application/services/lending.capability.service.ts
@@ -1,0 +1,259 @@
+/**
+ * LendingCapabilityService — facade for the lending capability.
+ *
+ * Orchestrates ProviderRegistry<ILendingProvider> + IPriorityPolicy so routes never
+ * import concrete adapters. All /v1/capability/lend/* endpoints go through this class.
+ *
+ * Provider priority (chain 43114):
+ *   1. execution-layer  — prepare-* + reads (primary)
+ *   2. benqi            — reads only, fallback when execution-layer is down
+ */
+
+import {
+  CapabilityError,
+  fallbackInvoke,
+  type Address,
+  type CapabilityRequest,
+  type ChainId,
+  type IPriorityPolicy,
+  type ProviderRegistry,
+  type Transaction,
+} from "@panorama/capability";
+
+import type {
+  HistoryEntry,
+  ILendingProvider,
+  LendingMarket,
+  PrepareBorrowReq,
+  PrepareRepayReq,
+  PrepareSupplyReq,
+  PrepareWithdrawReq,
+  UserPositionsResult,
+} from "../../domain/ports/lending.provider.port";
+
+// ─── Public shapes ────────────────────────────────────────────────────────────
+
+export interface LendingFacadeDeps {
+  registry: ProviderRegistry<ILendingProvider>;
+  policy: IPriorityPolicy;
+}
+
+export interface LendingActionOutcome<TData> {
+  data: TData;
+  provider: { name: string; metadata?: Record<string, unknown> };
+  attempts: { provider: string; reason: string }[];
+}
+
+// ─── Service ─────────────────────────────────────────────────────────────────
+
+export class LendingCapabilityService {
+  private readonly registry: ProviderRegistry<ILendingProvider>;
+  private readonly policy: IPriorityPolicy;
+
+  constructor(deps: LendingFacadeDeps) {
+    this.registry = deps.registry;
+    this.policy = deps.policy;
+  }
+
+  // ─── Markets (read) ──────────────────────────────────────────────────────
+
+  async getMarkets(
+    req: CapabilityRequest<Record<string, never>>,
+  ): Promise<LendingActionOutcome<LendingMarket[]>> {
+    const ranked = this.rankCandidates(req.chainId, "markets");
+    const outcome = await fallbackInvoke({
+      ranked,
+      supportsRoute: (p) => p.supportsRoute({ chainId: req.chainId, action: "markets" }),
+      invoke: (p) => p.getMarkets(req.chainId),
+      capability: "lending",
+    });
+    if (!outcome.ok) throw outcome.error;
+    return {
+      data: outcome.result,
+      provider: { name: (outcome as any).provider.name },
+      attempts: outcome.attempts,
+    };
+  }
+
+  // ─── Position (read) ─────────────────────────────────────────────────────
+
+  async getUserPosition(
+    req: CapabilityRequest<Record<string, never>>,
+  ): Promise<LendingActionOutcome<UserPositionsResult>> {
+    const ranked = this.rankCandidates(req.chainId, "position");
+    const outcome = await fallbackInvoke({
+      ranked,
+      supportsRoute: (p) => p.supportsRoute({ chainId: req.chainId, action: "position" }),
+      invoke: (p) => p.getUserPosition(req.userAddress, req.chainId),
+      capability: "lending",
+    });
+    if (!outcome.ok) throw outcome.error;
+    return {
+      data: outcome.result,
+      provider: { name: (outcome as any).provider.name },
+      attempts: outcome.attempts,
+    };
+  }
+
+  // ─── Prepare supply ──────────────────────────────────────────────────────
+
+  async prepareSupply(
+    req: CapabilityRequest<{ qTokenAddress: Address; amount: string }>,
+  ): Promise<LendingActionOutcome<Transaction[]>> {
+    const { qTokenAddress, amount } = req.payload;
+    const input: PrepareSupplyReq = {
+      userAddress: req.userAddress,
+      chainId: req.chainId,
+      qTokenAddress,
+      amount,
+    };
+    const ranked = this.rankCandidates(req.chainId, "supply", qTokenAddress);
+    const outcome = await fallbackInvoke({
+      ranked,
+      supportsRoute: (p) =>
+        p.supportsRoute({ chainId: req.chainId, action: "supply", qTokenAddress }),
+      invoke: (p) => p.prepareSupply(input),
+      capability: "lending",
+      shouldFallback: (err) =>
+        CapabilityError.is(err) && (err as CapabilityError).category === "VALIDATION"
+          ? "rethrow"
+          : "fallback",
+    });
+    if (!outcome.ok) throw outcome.error;
+    return {
+      data: outcome.result,
+      provider: { name: (outcome as any).provider.name },
+      attempts: outcome.attempts,
+    };
+  }
+
+  // ─── Prepare withdraw ────────────────────────────────────────────────────
+
+  async prepareWithdraw(
+    req: CapabilityRequest<{ qTokenAddress: Address; amount: string; byUnderlying?: boolean }>,
+  ): Promise<LendingActionOutcome<Transaction[]>> {
+    const { qTokenAddress, amount, byUnderlying } = req.payload;
+    const input: PrepareWithdrawReq = {
+      userAddress: req.userAddress,
+      chainId: req.chainId,
+      qTokenAddress,
+      amount,
+      byUnderlying,
+    };
+    const ranked = this.rankCandidates(req.chainId, "withdraw", qTokenAddress);
+    const outcome = await fallbackInvoke({
+      ranked,
+      supportsRoute: (p) =>
+        p.supportsRoute({ chainId: req.chainId, action: "withdraw", qTokenAddress }),
+      invoke: (p) => p.prepareWithdraw(input),
+      capability: "lending",
+    });
+    if (!outcome.ok) throw outcome.error;
+    return {
+      data: outcome.result,
+      provider: { name: (outcome as any).provider.name },
+      attempts: outcome.attempts,
+    };
+  }
+
+  // ─── Prepare borrow ──────────────────────────────────────────────────────
+
+  async prepareBorrow(
+    req: CapabilityRequest<{ qTokenAddress: Address; amount: string }>,
+  ): Promise<LendingActionOutcome<Transaction[]>> {
+    const { qTokenAddress, amount } = req.payload;
+    const input: PrepareBorrowReq = {
+      userAddress: req.userAddress,
+      chainId: req.chainId,
+      qTokenAddress,
+      amount,
+    };
+    const ranked = this.rankCandidates(req.chainId, "borrow", qTokenAddress);
+    const outcome = await fallbackInvoke({
+      ranked,
+      supportsRoute: (p) =>
+        p.supportsRoute({ chainId: req.chainId, action: "borrow", qTokenAddress }),
+      invoke: (p) => p.prepareBorrow(input),
+      capability: "lending",
+    });
+    if (!outcome.ok) throw outcome.error;
+    return {
+      data: outcome.result,
+      provider: { name: (outcome as any).provider.name },
+      attempts: outcome.attempts,
+    };
+  }
+
+  // ─── Prepare repay ───────────────────────────────────────────────────────
+
+  async prepareRepay(
+    req: CapabilityRequest<{ qTokenAddress: Address; amount: string }>,
+  ): Promise<LendingActionOutcome<Transaction[]>> {
+    const { qTokenAddress, amount } = req.payload;
+    const input: PrepareRepayReq = {
+      userAddress: req.userAddress,
+      chainId: req.chainId,
+      qTokenAddress,
+      amount,
+    };
+    const ranked = this.rankCandidates(req.chainId, "repay", qTokenAddress);
+    const outcome = await fallbackInvoke({
+      ranked,
+      supportsRoute: (p) =>
+        p.supportsRoute({ chainId: req.chainId, action: "repay", qTokenAddress }),
+      invoke: (p) => p.prepareRepay(input),
+      capability: "lending",
+    });
+    if (!outcome.ok) throw outcome.error;
+    return {
+      data: outcome.result,
+      provider: { name: (outcome as any).provider.name },
+      attempts: outcome.attempts,
+    };
+  }
+
+  // ─── History (read) ──────────────────────────────────────────────────────
+
+  async getHistory(
+    req: CapabilityRequest<Record<string, never>>,
+  ): Promise<LendingActionOutcome<HistoryEntry[]>> {
+    const ranked = this.rankCandidates(req.chainId, "history");
+    const outcome = await fallbackInvoke({
+      ranked,
+      supportsRoute: (p) => p.supportsRoute({ chainId: req.chainId, action: "history" }),
+      invoke: (p) => p.getHistory(req.userAddress, req.chainId),
+      capability: "lending",
+    });
+    if (!outcome.ok) throw outcome.error;
+    return {
+      data: outcome.result,
+      provider: { name: (outcome as any).provider.name },
+      attempts: outcome.attempts,
+    };
+  }
+
+  // ─── Discovery ───────────────────────────────────────────────────────────
+
+  listProviders(): ILendingProvider[] {
+    return this.registry.listAll({ capability: "lending" });
+  }
+
+  // ─── Internals ───────────────────────────────────────────────────────────
+
+  private rankCandidates(
+    chainId: ChainId,
+    action: string,
+    asset?: string,
+  ): ILendingProvider[] {
+    const candidates = this.registry.listByChain(chainId, { capability: "lending" });
+    if (candidates.length === 0) {
+      throw CapabilityError.unsupportedRoute({
+        capability: "lending",
+        chainId,
+        attempted: [],
+        ...(asset && { fromAsset: asset }),
+      });
+    }
+    return this.policy.rank(candidates, { chainId, action, ...(asset && { asset }) });
+  }
+}

--- a/lending-service/src/domain/ports/lending.provider.port.ts
+++ b/lending-service/src/domain/ports/lending.provider.port.ts
@@ -1,0 +1,182 @@
+/**
+ * ILendingProvider — lending capability port.
+ *
+ * Every lending provider (ExecutionLayer, Benqi direct) implements this interface.
+ * The LendingCapabilityService facade speaks only this port — never a concrete adapter.
+ *
+ * Avalanche / Benqi focus (chainId 43114) but typed generically so other chains can be added.
+ *
+ * See ADR 002 + shared/capability/CONVENTIONS.md.
+ */
+
+import type {
+  Address,
+  ChainId,
+  ICapabilityProvider,
+  Transaction,
+  WeiString,
+} from "@panorama/capability";
+
+// ─── Route params ─────────────────────────────────────────────────────────────
+
+export interface LendingRouteParams {
+  chainId: ChainId;
+  /** "supply" | "withdraw" | "borrow" | "repay" | "markets" | "position" | "history" */
+  action: string;
+  /** qToken / market address — required for action-specific routes. */
+  qTokenAddress?: Address;
+}
+
+// ─── Domain entities ──────────────────────────────────────────────────────────
+
+export interface LendingMarket {
+  chainId: ChainId;
+  protocol: string;
+  qTokenAddress: Address;
+  qTokenSymbol: string;
+  underlyingAddress: Address | "native";
+  underlyingSymbol: string;
+  underlyingDecimals: number;
+  collateralFactorBps: number | null;
+  supplyApyBps: number | null;
+  borrowApyBps: number | null;
+}
+
+export interface UserPosition {
+  chainId: ChainId;
+  protocol: string;
+  qTokenAddress: Address;
+  qTokenSymbol: string;
+  underlyingAddress: Address | "native";
+  underlyingSymbol: string;
+  underlyingDecimals: number;
+  qTokenDecimals: number;
+  qTokenBalanceWei: WeiString;
+  suppliedWei: WeiString;
+  borrowedWei: WeiString;
+  collateralEnabled: boolean;
+}
+
+export interface AccountLiquidity {
+  accountAddress: Address;
+  liquidity: WeiString;
+  shortfall: WeiString;
+  isHealthy: boolean;
+}
+
+export interface UserPositionsResult {
+  accountAddress: Address;
+  liquidity: AccountLiquidity;
+  positions: UserPosition[];
+  updatedAt: number;
+  warnings?: string[];
+}
+
+export interface HistoryEntry {
+  id: string;
+  action: "supply" | "withdraw" | "borrow" | "repay";
+  qTokenAddress: Address;
+  amountWei: WeiString;
+  status: "pending" | "confirmed" | "failed";
+  txHash?: string;
+  createdAt: string;
+}
+
+// ─── Prepare-action request shapes ───────────────────────────────────────────
+
+export interface PrepareSupplyReq {
+  userAddress: Address;
+  chainId: ChainId;
+  qTokenAddress: Address;
+  /** Amount in wei (underlying). */
+  amount: WeiString;
+}
+
+export interface PrepareWithdrawReq {
+  userAddress: Address;
+  chainId: ChainId;
+  qTokenAddress: Address;
+  /** qToken amount when redeeming by receipt token; underlying when redeeming by asset. */
+  amount: WeiString;
+  /** true = redeem by underlying amount (redeemUnderlying); false = by qToken amount (redeem). */
+  byUnderlying?: boolean;
+}
+
+export interface PrepareBorrowReq {
+  userAddress: Address;
+  chainId: ChainId;
+  qTokenAddress: Address;
+  amount: WeiString;
+}
+
+export interface PrepareRepayReq {
+  userAddress: Address;
+  chainId: ChainId;
+  qTokenAddress: Address;
+  amount: WeiString;
+}
+
+// ─── Quote shape ──────────────────────────────────────────────────────────────
+
+export interface LendingQuote {
+  qTokenAddress: Address;
+  estimatedAmount: WeiString;
+  feeWei: WeiString;
+  netAmount: WeiString;
+  /** Optional extra data from the provider (e.g. validation fee breakdown). */
+  extra?: Record<string, unknown>;
+}
+
+// ─── The port ─────────────────────────────────────────────────────────────────
+
+export interface ILendingProvider extends ICapabilityProvider {
+  /**
+   * True if this provider can serve the given action / qToken / chain combination.
+   * The registry already filters by `metadata.supportedChains`; this is for finer-grained
+   * checks (e.g. ExecutionLayer handles prepare actions; Benqi handles reads only).
+   */
+  supportsRoute(params: LendingRouteParams): Promise<boolean>;
+
+  /**
+   * Return all lending markets available on the given chain.
+   */
+  getMarkets(chainId: ChainId): Promise<LendingMarket[]>;
+
+  /**
+   * Return all open positions (supply + borrow) for a user.
+   */
+  getUserPosition(userAddress: Address, chainId: ChainId): Promise<UserPositionsResult>;
+
+  /**
+   * Build the transaction set needed to supply `req.amount` of underlying into `req.qTokenAddress`.
+   * May include an ERC-20 approve step before the mint call.
+   */
+  prepareSupply(req: PrepareSupplyReq): Promise<Transaction[]>;
+
+  /**
+   * Build the transaction set needed to withdraw (redeem) from a qToken market.
+   */
+  prepareWithdraw(req: PrepareWithdrawReq): Promise<Transaction[]>;
+
+  /**
+   * Build the transaction needed to borrow `req.amount` from a qToken market.
+   */
+  prepareBorrow(req: PrepareBorrowReq): Promise<Transaction[]>;
+
+  /**
+   * Build the transaction needed to repay an outstanding borrow.
+   * May include an ERC-20 approve step.
+   */
+  prepareRepay(req: PrepareRepayReq): Promise<Transaction[]>;
+
+  /**
+   * Return lending transaction history for a user (from DB gateway or on-chain index).
+   * Returns an empty array when history is unavailable — never throws for missing history.
+   */
+  getHistory(userAddress: Address, chainId: ChainId): Promise<HistoryEntry[]>;
+
+  /**
+   * Optional health probe. If absent the provider is treated as always healthy.
+   */
+  healthCheck?(): Promise<import("@panorama/capability").ProviderHealth>;
+}

--- a/lending-service/src/infrastructure/adapters/benqi.lending.adapter.ts
+++ b/lending-service/src/infrastructure/adapters/benqi.lending.adapter.ts
@@ -1,0 +1,214 @@
+/**
+ * BenqiLendingAdapter — fallback read-only lending provider.
+ *
+ * Calls the legacy /benqi/* routes of this very service (localhost:3007 in production)
+ * to fetch market data and user positions. It does NOT prepare transactions — that
+ * responsibility stays with ExecutionLayerLendingAdapter.
+ *
+ * supportsRoute returns false for any prepare-* action so the registry
+ * never routes those here.
+ */
+
+import {
+  CapabilityError,
+  type ProviderHealth,
+  type ProviderMetadata,
+  type Transaction,
+} from "@panorama/capability";
+
+import type {
+  HistoryEntry,
+  ILendingProvider,
+  LendingMarket,
+  LendingRouteParams,
+  PrepareBorrowReq,
+  PrepareRepayReq,
+  PrepareSupplyReq,
+  PrepareWithdrawReq,
+  UserPositionsResult,
+} from "../../domain/ports/lending.provider.port";
+
+const PREPARE_ACTIONS = new Set(["supply", "withdraw", "borrow", "repay"]);
+
+async function safeJson(res: Response): Promise<any> {
+  const text = await res.text();
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error(`Non-JSON response (${res.status}): ${text.slice(0, 120)}`);
+  }
+}
+
+export class BenqiLendingAdapter implements ILendingProvider {
+  readonly name = "benqi";
+  readonly metadata: ProviderMetadata = {
+    name: "benqi",
+    capability: "lending",
+    supportedChains: [43114],
+    features: ["markets", "position", "history"],
+    version: "1.0.0",
+  };
+
+  private readonly selfBaseUrl: string;
+
+  constructor(selfBaseUrl?: string) {
+    // Points back to this service's own legacy routes.
+    this.selfBaseUrl =
+      selfBaseUrl ??
+      `http://localhost:${process.env.PORT ?? 3007}`;
+  }
+
+  private async get<T>(path: string): Promise<T> {
+    const res = await fetch(`${this.selfBaseUrl}${path}`);
+    return safeJson(res);
+  }
+
+  // ─── ILendingProvider ────────────────────────────────────────────────────
+
+  async supportsRoute(params: LendingRouteParams): Promise<boolean> {
+    if (!this.metadata.supportedChains.includes(params.chainId)) return false;
+    // Benqi adapter is read-only: never handle prepare-* actions.
+    if (PREPARE_ACTIONS.has(params.action)) return false;
+    return true;
+  }
+
+  async getMarkets(chainId: number): Promise<LendingMarket[]> {
+    try {
+      const data = await this.get<any>("/benqi/markets");
+      const raw = data.data?.markets ?? data.markets ?? [];
+      return raw.map((m: any) => ({
+        chainId: m.chainId ?? chainId,
+        protocol: m.protocol ?? "benqi",
+        qTokenAddress: m.qTokenAddress,
+        qTokenSymbol: m.qTokenSymbol,
+        underlyingAddress: m.underlyingAddress ?? "native",
+        underlyingSymbol: m.underlyingSymbol,
+        underlyingDecimals: m.underlyingDecimals ?? 18,
+        collateralFactorBps: m.collateralFactorBps ?? null,
+        supplyApyBps: m.supplyApyBps ?? null,
+        borrowApyBps: m.borrowApyBps ?? null,
+      }));
+    } catch (err) {
+      throw CapabilityError.providerFailure({
+        capability: "lending",
+        provider: this.name,
+        message: `Benqi getMarkets failed: ${(err as Error).message ?? err}`,
+        cause: err,
+      });
+    }
+  }
+
+  async getUserPosition(userAddress: string, chainId: number): Promise<UserPositionsResult> {
+    try {
+      const data = await this.get<any>(`/benqi/account/${userAddress}/positions`);
+      // Legacy route wraps in { data: { positions, liquidity, ... } }
+      const inner = data.data ?? data;
+      return {
+        accountAddress: userAddress,
+        liquidity: {
+          accountAddress: userAddress,
+          liquidity: inner.liquidity?.liquidity ?? "0",
+          shortfall: inner.liquidity?.shortfall ?? "0",
+          isHealthy: inner.liquidity?.isHealthy ?? true,
+        },
+        positions: (inner.positions ?? []).map((p: any) => ({
+          chainId: p.chainId ?? chainId,
+          protocol: p.protocol ?? "benqi",
+          qTokenAddress: p.qTokenAddress,
+          qTokenSymbol: p.qTokenSymbol,
+          underlyingAddress: p.underlyingAddress ?? "native",
+          underlyingSymbol: p.underlyingSymbol,
+          underlyingDecimals: p.underlyingDecimals ?? 18,
+          qTokenDecimals: p.qTokenDecimals ?? 8,
+          qTokenBalanceWei: p.qTokenBalanceWei ?? "0",
+          suppliedWei: p.suppliedWei ?? "0",
+          borrowedWei: p.borrowedWei ?? "0",
+          collateralEnabled: p.collateralEnabled ?? false,
+        })),
+        updatedAt: inner.updatedAt ?? Date.now(),
+        ...(inner.warnings?.length ? { warnings: inner.warnings } : {}),
+      };
+    } catch (err) {
+      throw CapabilityError.providerFailure({
+        capability: "lending",
+        provider: this.name,
+        message: `Benqi getUserPosition failed: ${(err as Error).message ?? err}`,
+        cause: err,
+      });
+    }
+  }
+
+  // Prepare actions are not supported — these will never be called because
+  // supportsRoute returns false for them, but we implement them to satisfy the interface.
+
+  async prepareSupply(_req: PrepareSupplyReq): Promise<Transaction[]> {
+    throw CapabilityError.unsupportedRoute({
+      capability: "lending",
+      chainId: _req.chainId,
+      attempted: [this.name],
+    });
+  }
+
+  async prepareWithdraw(_req: PrepareWithdrawReq): Promise<Transaction[]> {
+    throw CapabilityError.unsupportedRoute({
+      capability: "lending",
+      chainId: _req.chainId,
+      attempted: [this.name],
+    });
+  }
+
+  async prepareBorrow(_req: PrepareBorrowReq): Promise<Transaction[]> {
+    throw CapabilityError.unsupportedRoute({
+      capability: "lending",
+      chainId: _req.chainId,
+      attempted: [this.name],
+    });
+  }
+
+  async prepareRepay(_req: PrepareRepayReq): Promise<Transaction[]> {
+    throw CapabilityError.unsupportedRoute({
+      capability: "lending",
+      chainId: _req.chainId,
+      attempted: [this.name],
+    });
+  }
+
+  async getHistory(userAddress: string, _chainId: number): Promise<HistoryEntry[]> {
+    try {
+      const data = await this.get<any>(`/benqi/account/${userAddress}/history`);
+      const txs = data.data?.transactions ?? [];
+      return txs.map((t: any) => ({
+        id: t.id ?? t._id ?? String(Math.random()),
+        action: t.action,
+        qTokenAddress: t.metadata?.qTokenAddress ?? "",
+        amountWei: t.amountWei ?? "0",
+        status: t.status ?? "confirmed",
+        txHash: t.txHash,
+        createdAt: t.createdAt ?? new Date().toISOString(),
+      }));
+    } catch {
+      return [];
+    }
+  }
+
+  async healthCheck(): Promise<ProviderHealth> {
+    const start = Date.now();
+    try {
+      const data = await this.get<any>("/health");
+      const healthy = data?.status === "healthy" || data?.status === "degraded";
+      return {
+        healthy,
+        latencyMs: Date.now() - start,
+        reason: healthy ? undefined : `status=${data?.status}`,
+        checkedAt: new Date().toISOString(),
+      };
+    } catch (err) {
+      return {
+        healthy: false,
+        latencyMs: Date.now() - start,
+        reason: String((err as Error).message ?? err),
+        checkedAt: new Date().toISOString(),
+      };
+    }
+  }
+}

--- a/lending-service/src/infrastructure/adapters/execution-layer.lending.adapter.ts
+++ b/lending-service/src/infrastructure/adapters/execution-layer.lending.adapter.ts
@@ -1,0 +1,308 @@
+/**
+ * ExecutionLayerLendingAdapter — primary lending provider.
+ *
+ * Delegates prepare-* actions and position reads to the execution-layer service
+ * via HTTP (EXECUTION_LAYER_URL env var, default localhost:3011).
+ *
+ * Circuit breaker: 3 consecutive failures → marks unhealthy for 60s.
+ * After 60s the next call re-attempts and, if it succeeds, resets the breaker.
+ */
+
+import {
+  CapabilityError,
+  type ProviderHealth,
+  type ProviderMetadata,
+  type Transaction,
+} from "@panorama/capability";
+
+import type {
+  AccountLiquidity,
+  HistoryEntry,
+  ILendingProvider,
+  LendingMarket,
+  LendingRouteParams,
+  PrepareBorrowReq,
+  PrepareRepayReq,
+  PrepareSupplyReq,
+  PrepareWithdrawReq,
+  UserPosition,
+  UserPositionsResult,
+} from "../../domain/ports/lending.provider.port";
+
+// ─── Circuit breaker state ────────────────────────────────────────────────────
+
+const FAILURE_THRESHOLD = 3;
+const OPEN_DURATION_MS = 60_000;
+
+interface BreakerState {
+  failures: number;
+  openedAt: number | null;
+}
+
+// ─── HTTP helpers ─────────────────────────────────────────────────────────────
+
+function isConnectionError(err: unknown): boolean {
+  const msg = String((err as any)?.message ?? err);
+  const code = String((err as any)?.cause?.code ?? (err as any)?.code ?? "");
+  return (
+    ["ECONNREFUSED", "ECONNRESET", "ENOTFOUND", "UND_ERR_CONNECT_TIMEOUT"].includes(code) ||
+    /fetch failed|ECONNREFUSED|not valid JSON/i.test(msg)
+  );
+}
+
+async function safeJson(res: Response): Promise<any> {
+  const text = await res.text();
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error(`Non-JSON response (${res.status}): ${text.slice(0, 120)}`);
+  }
+}
+
+/**
+ * Map an execution-layer TransactionBundle steps array → canonical Transaction[].
+ * Steps come as { to, data, value, chainId } — matches the Transaction shape directly.
+ */
+function stepsToTransactions(steps: any[]): Transaction[] {
+  return (steps ?? []).map((s: any) => ({
+    chainId: s.chainId ?? 43114,
+    to: s.to,
+    data: s.data ?? "0x",
+    value: String(s.value ?? "0"),
+    ...(s.gasLimit && { gasLimit: String(s.gasLimit) }),
+    feeMode: "advisory" as const,
+    action: s.action,
+    description: s.description,
+  }));
+}
+
+// ─── Adapter ──────────────────────────────────────────────────────────────────
+
+export class ExecutionLayerLendingAdapter implements ILendingProvider {
+  readonly name = "execution-layer";
+  readonly metadata: ProviderMetadata = {
+    name: "execution-layer",
+    capability: "lending",
+    supportedChains: [43114],
+    features: ["supply", "withdraw", "borrow", "repay", "markets", "position"],
+    version: "1.0.0",
+  };
+
+  private readonly baseUrl: string;
+  private readonly breaker: BreakerState = { failures: 0, openedAt: null };
+
+  constructor(baseUrl?: string) {
+    this.baseUrl = baseUrl ?? process.env.EXECUTION_LAYER_URL ?? "http://localhost:3011";
+  }
+
+  // ─── Circuit breaker helpers ─────────────────────────────────────────────
+
+  private isOpen(): boolean {
+    if (this.breaker.openedAt === null) return false;
+    return Date.now() - this.breaker.openedAt < OPEN_DURATION_MS;
+  }
+
+  private recordSuccess(): void {
+    this.breaker.failures = 0;
+    this.breaker.openedAt = null;
+  }
+
+  private recordFailure(): void {
+    this.breaker.failures += 1;
+    if (this.breaker.failures >= FAILURE_THRESHOLD) {
+      this.breaker.openedAt = Date.now();
+    }
+  }
+
+  private assertNotOpen(action: string): void {
+    if (this.isOpen()) {
+      throw CapabilityError.providerFailure({
+        capability: "lending",
+        provider: this.name,
+        message: `ExecutionLayer circuit breaker open — ${action} skipped. Retry in ${Math.ceil((OPEN_DURATION_MS - (Date.now() - (this.breaker.openedAt ?? 0))) / 1000)}s.`,
+      });
+    }
+  }
+
+  // ─── HTTP calls ──────────────────────────────────────────────────────────
+
+  private async get<T>(path: string): Promise<T> {
+    const res = await fetch(`${this.baseUrl}${path}`);
+    return safeJson(res);
+  }
+
+  private async post<T>(path: string, body: unknown): Promise<T> {
+    const res = await fetch(`${this.baseUrl}${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    return safeJson(res);
+  }
+
+  private wrapError(action: string, err: unknown): never {
+    this.recordFailure();
+    if (CapabilityError.is(err)) throw err;
+    throw CapabilityError.providerFailure({
+      capability: "lending",
+      provider: this.name,
+      message: `ExecutionLayer ${action} failed: ${(err as Error).message ?? err}`,
+      cause: err,
+    });
+  }
+
+  // ─── ILendingProvider ────────────────────────────────────────────────────
+
+  async supportsRoute(params: LendingRouteParams): Promise<boolean> {
+    if (!this.metadata.supportedChains.includes(params.chainId)) return false;
+    // ExecutionLayer handles all actions including prepare-*
+    return true;
+  }
+
+  async getMarkets(chainId: number): Promise<LendingMarket[]> {
+    this.assertNotOpen("getMarkets");
+    try {
+      const data = await this.get<any>("/avax/lending/markets");
+      this.recordSuccess();
+      const markets: LendingMarket[] = (data.markets ?? data.data?.markets ?? []).map((m: any) => ({
+        chainId: m.chainId ?? chainId,
+        protocol: m.protocol ?? "benqi",
+        qTokenAddress: m.qTokenAddress,
+        qTokenSymbol: m.qTokenSymbol,
+        underlyingAddress: m.underlyingAddress ?? "native",
+        underlyingSymbol: m.underlyingSymbol,
+        underlyingDecimals: m.underlyingDecimals ?? 18,
+        collateralFactorBps: m.collateralFactorBps ?? null,
+        supplyApyBps: m.supplyApyBps ?? null,
+        borrowApyBps: m.borrowApyBps ?? null,
+      }));
+      return markets;
+    } catch (err) {
+      this.wrapError("getMarkets", err);
+    }
+  }
+
+  async getUserPosition(userAddress: string, chainId: number): Promise<UserPositionsResult> {
+    this.assertNotOpen("getUserPosition");
+    try {
+      const data = await this.get<any>(`/avax/lending/position/${userAddress}`);
+      this.recordSuccess();
+
+      const positions: UserPosition[] = (data.positions ?? []).map((p: any) => ({
+        chainId: p.chainId ?? chainId,
+        protocol: p.protocol ?? "benqi",
+        qTokenAddress: p.qTokenAddress,
+        qTokenSymbol: p.qTokenSymbol,
+        underlyingAddress: p.underlyingAddress ?? "native",
+        underlyingSymbol: p.underlyingSymbol,
+        underlyingDecimals: p.underlyingDecimals ?? 18,
+        qTokenDecimals: p.qTokenDecimals ?? 8,
+        qTokenBalanceWei: p.qTokenBalance ?? p.qTokenBalanceWei ?? "0",
+        suppliedWei: p.suppliedWei ?? "0",
+        borrowedWei: p.borrowedWei ?? "0",
+        collateralEnabled: p.collateralEnabled ?? true,
+      }));
+
+      const liquidity: AccountLiquidity = {
+        accountAddress: userAddress,
+        liquidity: data.liquidity?.liquidity ?? "0",
+        shortfall: data.liquidity?.shortfall ?? "0",
+        isHealthy: data.liquidity?.isHealthy ?? true,
+      };
+
+      return {
+        accountAddress: userAddress,
+        liquidity,
+        positions,
+        updatedAt: Date.now(),
+      };
+    } catch (err) {
+      this.wrapError("getUserPosition", err);
+    }
+  }
+
+  async prepareSupply(req: PrepareSupplyReq): Promise<Transaction[]> {
+    this.assertNotOpen("prepareSupply");
+    try {
+      const data = await this.post<any>("/avax/lending/prepare-supply", {
+        userAddress: req.userAddress,
+        qTokenAddress: req.qTokenAddress,
+        amount: req.amount,
+      });
+      this.recordSuccess();
+      if (data.error) throw new Error(data.error);
+      return stepsToTransactions(data.bundle?.steps ?? []);
+    } catch (err) {
+      this.wrapError("prepareSupply", err);
+    }
+  }
+
+  async prepareWithdraw(req: PrepareWithdrawReq): Promise<Transaction[]> {
+    this.assertNotOpen("prepareWithdraw");
+    try {
+      const data = await this.post<any>("/avax/lending/prepare-redeem", {
+        userAddress: req.userAddress,
+        qTokenAddress: req.qTokenAddress,
+        qTokenAmount: req.byUnderlying ? undefined : req.amount,
+        underlyingAmount: req.byUnderlying ? req.amount : undefined,
+      });
+      this.recordSuccess();
+      if (data.error) throw new Error(data.error);
+      return stepsToTransactions(data.bundle?.steps ?? []);
+    } catch (err) {
+      this.wrapError("prepareWithdraw", err);
+    }
+  }
+
+  async prepareBorrow(req: PrepareBorrowReq): Promise<Transaction[]> {
+    this.assertNotOpen("prepareBorrow");
+    try {
+      const data = await this.post<any>("/avax/lending/prepare-borrow", {
+        userAddress: req.userAddress,
+        qTokenAddress: req.qTokenAddress,
+        amount: req.amount,
+      });
+      this.recordSuccess();
+      if (data.error) throw new Error(data.error);
+      return stepsToTransactions(data.bundle?.steps ?? []);
+    } catch (err) {
+      this.wrapError("prepareBorrow", err);
+    }
+  }
+
+  async prepareRepay(req: PrepareRepayReq): Promise<Transaction[]> {
+    this.assertNotOpen("prepareRepay");
+    try {
+      const data = await this.post<any>("/avax/lending/prepare-repay", {
+        userAddress: req.userAddress,
+        qTokenAddress: req.qTokenAddress,
+        amount: req.amount,
+      });
+      this.recordSuccess();
+      if (data.error) throw new Error(data.error);
+      return stepsToTransactions(data.bundle?.steps ?? []);
+    } catch (err) {
+      this.wrapError("prepareRepay", err);
+    }
+  }
+
+  async getHistory(_userAddress: string, _chainId: number): Promise<HistoryEntry[]> {
+    // Execution layer does not expose a history endpoint; fall through to Benqi/DB-gateway adapter.
+    return [];
+  }
+
+  async healthCheck(): Promise<ProviderHealth> {
+    const start = Date.now();
+    try {
+      await this.get<any>("/health");
+      return { healthy: true, latencyMs: Date.now() - start, checkedAt: new Date().toISOString() };
+    } catch (err) {
+      return {
+        healthy: false,
+        latencyMs: Date.now() - start,
+        reason: isConnectionError(err) ? "unreachable" : String((err as Error).message ?? err),
+        checkedAt: new Date().toISOString(),
+      };
+    }
+  }
+}

--- a/lending-service/src/infrastructure/di/container.ts
+++ b/lending-service/src/infrastructure/di/container.ts
@@ -1,0 +1,96 @@
+/**
+ * Lending Capability — composition root.
+ *
+ * Wires the ProviderRegistry, instantiates both adapters, sets the priority policy,
+ * mounts the health tracker, and returns the facade + discovery handler ready for
+ * the HTTP layer.
+ *
+ * Provider priority on chain 43114:
+ *   1. execution-layer (primary — handles all actions)
+ *   2. benqi           (fallback — read-only markets + positions)
+ */
+
+import {
+  ChainAssetPriorityPolicy,
+  ProviderHealthTracker,
+  ProviderRegistry,
+  createDiscoveryHandler,
+  type DiscoveryHandler,
+} from "@panorama/capability";
+
+import { ExecutionLayerLendingAdapter } from "../adapters/execution-layer.lending.adapter";
+import { BenqiLendingAdapter } from "../adapters/benqi.lending.adapter";
+import { LendingCapabilityService } from "../../application/services/lending.capability.service";
+import type { ILendingProvider } from "../../domain/ports/lending.provider.port";
+
+export interface LendingContainer {
+  facade: LendingCapabilityService;
+  registry: ProviderRegistry<ILendingProvider>;
+  healthTracker: ProviderHealthTracker;
+  discoveryHandler: DiscoveryHandler;
+  /** Call on server start to begin health polling. */
+  start(): void;
+  /** Call on graceful shutdown. */
+  stop(): void;
+}
+
+export interface BuildLendingContainerOptions {
+  /** Override the execution-layer base URL (default: EXECUTION_LAYER_URL env or localhost:3011). */
+  executionLayerUrl?: string;
+  /** Override the self base URL used by the Benqi adapter (default: localhost:PORT). */
+  selfBaseUrl?: string;
+  /** Skip auto-starting the health tracker (useful in tests). */
+  autoStartHealth?: boolean;
+}
+
+export function buildLendingContainer(
+  options: BuildLendingContainerOptions = {},
+): LendingContainer {
+  const registry = new ProviderRegistry<ILendingProvider>();
+
+  // Primary provider — execution layer handles all prepare-* and read routes
+  const executionLayer = new ExecutionLayerLendingAdapter(options.executionLayerUrl);
+  registry.register(executionLayer);
+
+  // Fallback provider — read-only Benqi direct (self-calls legacy routes)
+  const benqi = new BenqiLendingAdapter(options.selfBaseUrl);
+  registry.register(benqi);
+
+  // Priority policy: on Avalanche (43114) try execution-layer first, benqi second
+  const policy = new ChainAssetPriorityPolicy({
+    "43114": ["execution-layer", "benqi"],
+  });
+
+  // Health tracker — polls every 30s, opens circuit after 3 consecutive failures
+  const healthTracker = new ProviderHealthTracker({
+    intervalMs: 30_000,
+    unhealthyAfter: 3,
+    probeTimeoutMs: 5_000,
+    onError: (name: string, error: unknown) =>
+      console.warn(`[lending][health] ${name} probe failed: ${(error as Error).message ?? error}`),
+  });
+  registry.attachHealthOracle(healthTracker);
+  healthTracker.track(executionLayer);
+  healthTracker.track(benqi);
+
+  const facade = new LendingCapabilityService({ registry, policy });
+
+  const discoveryHandler = createDiscoveryHandler({
+    listProviders: () => registry.listAll({ capability: "lending" }),
+    snapshotHealth: () => healthTracker.snapshot(),
+    cacheTtlSeconds: 30,
+  });
+
+  return {
+    facade,
+    registry,
+    healthTracker,
+    discoveryHandler,
+    start: () => {
+      if (options.autoStartHealth !== false) healthTracker.start();
+    },
+    stop: () => {
+      healthTracker.stop();
+    },
+  };
+}

--- a/lending-service/src/infrastructure/http/routes/capability.router.ts
+++ b/lending-service/src/infrastructure/http/routes/capability.router.ts
@@ -1,0 +1,382 @@
+/**
+ * Lending Capability Router — /v1/capability/lend/*
+ *
+ * Mounts the new capability endpoints and re-exports legacy /benqi/* routes
+ * with Deprecation + Sunset headers so clients can migrate without a hard cutover.
+ *
+ * Endpoint map:
+ *   GET  /v1/capability/lend/markets
+ *   GET  /v1/capability/lend/position/:address
+ *   POST /v1/capability/lend/supply/quote
+ *   POST /v1/capability/lend/supply/prepare
+ *   POST /v1/capability/lend/withdraw/prepare
+ *   POST /v1/capability/lend/borrow/prepare
+ *   POST /v1/capability/lend/repay/prepare
+ *   GET  /v1/capability/lend/history/:address
+ *   GET  /v1/capability/_discovery
+ */
+
+import { Router, Request, Response } from "express";
+import { v4 as uuidv4 } from "uuid";
+import { buildSuccess, buildError, CapabilityError } from "@panorama/capability";
+import type { LendingCapabilityService } from "../../../application/services/lending.capability.service";
+import type { DiscoveryHandler } from "@panorama/capability";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const CHAIN_ID = 43114;
+const DEPRECATION_DATE = "Sun, 01 Feb 2026 00:00:00 GMT";
+
+function traceId(req: Request): string {
+  return (req.headers["x-trace-id"] as string) ?? uuidv4();
+}
+
+function wrapError(err: unknown, tid: string, res: Response): void {
+  const capErr = CapabilityError.is(err)
+    ? (err as CapabilityError)
+    : CapabilityError.internal("Unexpected error", err);
+  res.status(capErr.httpStatus).json(buildError({ error: capErr, traceId: tid, latencyMs: 0 }));
+}
+
+function buildCapabilityRequest<T>(
+  req: Request,
+  payload: T,
+  userAddress?: string,
+) {
+  return {
+    tenantId: (req.headers["x-tenant-id"] as string) ?? "default",
+    traceId: traceId(req),
+    chainId: CHAIN_ID,
+    userAddress: userAddress ?? (req.headers["x-user-address"] as string) ?? "",
+    payload,
+    receivedAt: new Date().toISOString(),
+  };
+}
+
+function validateAddress(address: string): boolean {
+  return /^0x[0-9a-fA-F]{40}$/.test(address);
+}
+
+function validateWei(value: unknown): value is string {
+  return typeof value === "string" && /^\d+$/.test(value);
+}
+
+function addDeprecationHeaders(res: Response): void {
+  res.setHeader("Deprecation", DEPRECATION_DATE);
+  res.setHeader("Sunset", DEPRECATION_DATE);
+  res.setHeader("Link", '</v1/capability/lend/markets>; rel="successor-version"');
+}
+
+// ─── Router factory ───────────────────────────────────────────────────────────
+
+export function createCapabilityRouter(
+  lendingService: LendingCapabilityService,
+  discoveryHandler: DiscoveryHandler,
+): Router {
+  const router = Router();
+
+  // ─── Discovery ─────────────────────────────────────────────────────────
+
+  router.get("/_discovery", (req: Request, res: Response) => {
+    const result = discoveryHandler({
+      traceId: traceId(req),
+      force: req.query["force"] === "true",
+    });
+    res.status(200).json(result);
+  });
+
+  // ─── GET /v1/capability/lend/markets ────────────────────────────────────
+
+  router.get("/lend/markets", async (req: Request, res: Response) => {
+    const tid = traceId(req);
+    const start = Date.now();
+    try {
+      const capReq = buildCapabilityRequest(req, {});
+      const outcome = await lendingService.getMarkets(capReq);
+      res.status(200).json(
+        buildSuccess({
+          data: outcome.data,
+          provider: outcome.provider,
+          traceId: tid,
+          latencyMs: Date.now() - start,
+          attemptedProviders: outcome.attempts,
+        }),
+      );
+    } catch (err) {
+      wrapError(err, tid, res);
+    }
+  });
+
+  // ─── GET /v1/capability/lend/position/:address ──────────────────────────
+
+  router.get("/lend/position/:address", async (req: Request, res: Response) => {
+    const tid = traceId(req);
+    const start = Date.now();
+    try {
+      const { address } = req.params;
+      if (!validateAddress(address)) {
+        throw CapabilityError.validation({
+          capability: "lending",
+          message: "Invalid wallet address",
+        });
+      }
+      const capReq = buildCapabilityRequest(req, {}, address);
+      const outcome = await lendingService.getUserPosition(capReq);
+      res.status(200).json(
+        buildSuccess({
+          data: outcome.data,
+          provider: outcome.provider,
+          traceId: tid,
+          latencyMs: Date.now() - start,
+          attemptedProviders: outcome.attempts,
+        }),
+      );
+    } catch (err) {
+      wrapError(err, tid, res);
+    }
+  });
+
+  // ─── POST /v1/capability/lend/supply/quote ───────────────────────────────
+
+  router.post("/lend/supply/quote", async (req: Request, res: Response) => {
+    const tid = traceId(req);
+    const start = Date.now();
+    try {
+      const { qTokenAddress, amount, userAddress } = req.body ?? {};
+      if (!validateAddress(qTokenAddress)) {
+        throw CapabilityError.validation({ capability: "lending", message: "Invalid qTokenAddress" });
+      }
+      if (!validateWei(amount)) {
+        throw CapabilityError.validation({ capability: "lending", message: "amount must be a decimal wei string" });
+      }
+      // Quote = no-fee passthrough (validation fee logic lives in execution-layer)
+      res.status(200).json(
+        buildSuccess({
+          data: {
+            qTokenAddress,
+            estimatedAmount: amount,
+            feeWei: "0",
+            netAmount: amount,
+          },
+          provider: { name: "lending-service" },
+          traceId: tid,
+          latencyMs: Date.now() - start,
+        }),
+      );
+    } catch (err) {
+      wrapError(err, tid, res);
+    }
+  });
+
+  // ─── POST /v1/capability/lend/supply/prepare ─────────────────────────────
+
+  router.post("/lend/supply/prepare", async (req: Request, res: Response) => {
+    const tid = traceId(req);
+    const start = Date.now();
+    try {
+      const { qTokenAddress, amount, userAddress } = req.body ?? {};
+      if (!validateAddress(userAddress)) {
+        throw CapabilityError.validation({ capability: "lending", message: "Invalid userAddress" });
+      }
+      if (!validateAddress(qTokenAddress)) {
+        throw CapabilityError.validation({ capability: "lending", message: "Invalid qTokenAddress" });
+      }
+      if (!validateWei(amount)) {
+        throw CapabilityError.validation({ capability: "lending", message: "amount must be a decimal wei string" });
+      }
+      const capReq = buildCapabilityRequest(req, { qTokenAddress, amount }, userAddress);
+      const outcome = await lendingService.prepareSupply(capReq);
+      res.status(200).json(
+        buildSuccess({
+          data: outcome.data,
+          provider: outcome.provider,
+          traceId: tid,
+          latencyMs: Date.now() - start,
+          attemptedProviders: outcome.attempts,
+        }),
+      );
+    } catch (err) {
+      wrapError(err, tid, res);
+    }
+  });
+
+  // ─── POST /v1/capability/lend/withdraw/prepare ───────────────────────────
+
+  router.post("/lend/withdraw/prepare", async (req: Request, res: Response) => {
+    const tid = traceId(req);
+    const start = Date.now();
+    try {
+      const { qTokenAddress, amount, byUnderlying, userAddress } = req.body ?? {};
+      if (!validateAddress(userAddress)) {
+        throw CapabilityError.validation({ capability: "lending", message: "Invalid userAddress" });
+      }
+      if (!validateAddress(qTokenAddress)) {
+        throw CapabilityError.validation({ capability: "lending", message: "Invalid qTokenAddress" });
+      }
+      if (!validateWei(amount)) {
+        throw CapabilityError.validation({ capability: "lending", message: "amount must be a decimal wei string" });
+      }
+      const capReq = buildCapabilityRequest(
+        req,
+        { qTokenAddress, amount, byUnderlying: byUnderlying !== false },
+        userAddress,
+      );
+      const outcome = await lendingService.prepareWithdraw(capReq);
+      res.status(200).json(
+        buildSuccess({
+          data: outcome.data,
+          provider: outcome.provider,
+          traceId: tid,
+          latencyMs: Date.now() - start,
+          attemptedProviders: outcome.attempts,
+        }),
+      );
+    } catch (err) {
+      wrapError(err, tid, res);
+    }
+  });
+
+  // ─── POST /v1/capability/lend/borrow/prepare ─────────────────────────────
+
+  router.post("/lend/borrow/prepare", async (req: Request, res: Response) => {
+    const tid = traceId(req);
+    const start = Date.now();
+    try {
+      const { qTokenAddress, amount, userAddress } = req.body ?? {};
+      if (!validateAddress(userAddress)) {
+        throw CapabilityError.validation({ capability: "lending", message: "Invalid userAddress" });
+      }
+      if (!validateAddress(qTokenAddress)) {
+        throw CapabilityError.validation({ capability: "lending", message: "Invalid qTokenAddress" });
+      }
+      if (!validateWei(amount)) {
+        throw CapabilityError.validation({ capability: "lending", message: "amount must be a decimal wei string" });
+      }
+      const capReq = buildCapabilityRequest(req, { qTokenAddress, amount }, userAddress);
+      const outcome = await lendingService.prepareBorrow(capReq);
+      res.status(200).json(
+        buildSuccess({
+          data: outcome.data,
+          provider: outcome.provider,
+          traceId: tid,
+          latencyMs: Date.now() - start,
+          attemptedProviders: outcome.attempts,
+        }),
+      );
+    } catch (err) {
+      wrapError(err, tid, res);
+    }
+  });
+
+  // ─── POST /v1/capability/lend/repay/prepare ──────────────────────────────
+
+  router.post("/lend/repay/prepare", async (req: Request, res: Response) => {
+    const tid = traceId(req);
+    const start = Date.now();
+    try {
+      const { qTokenAddress, amount, userAddress } = req.body ?? {};
+      if (!validateAddress(userAddress)) {
+        throw CapabilityError.validation({ capability: "lending", message: "Invalid userAddress" });
+      }
+      if (!validateAddress(qTokenAddress)) {
+        throw CapabilityError.validation({ capability: "lending", message: "Invalid qTokenAddress" });
+      }
+      if (!validateWei(amount)) {
+        throw CapabilityError.validation({ capability: "lending", message: "amount must be a decimal wei string" });
+      }
+      const capReq = buildCapabilityRequest(req, { qTokenAddress, amount }, userAddress);
+      const outcome = await lendingService.prepareRepay(capReq);
+      res.status(200).json(
+        buildSuccess({
+          data: outcome.data,
+          provider: outcome.provider,
+          traceId: tid,
+          latencyMs: Date.now() - start,
+          attemptedProviders: outcome.attempts,
+        }),
+      );
+    } catch (err) {
+      wrapError(err, tid, res);
+    }
+  });
+
+  // ─── GET /v1/capability/lend/history/:address ────────────────────────────
+
+  router.get("/lend/history/:address", async (req: Request, res: Response) => {
+    const tid = traceId(req);
+    const start = Date.now();
+    try {
+      const { address } = req.params;
+      if (!validateAddress(address)) {
+        throw CapabilityError.validation({ capability: "lending", message: "Invalid wallet address" });
+      }
+      const capReq = buildCapabilityRequest(req, {}, address);
+      const outcome = await lendingService.getHistory(capReq);
+      res.status(200).json(
+        buildSuccess({
+          data: outcome.data,
+          provider: outcome.provider,
+          traceId: tid,
+          latencyMs: Date.now() - start,
+        }),
+      );
+    } catch (err) {
+      wrapError(err, tid, res);
+    }
+  });
+
+  // ─── Legacy routes with Deprecation headers ──────────────────────────────
+
+  /**
+   * GET /v1/capability/lend/legacy/markets → proxies to the new markets endpoint
+   * Kept for backward-compat; adds Deprecation + Sunset headers.
+   */
+  router.get("/lend/legacy/markets", async (req: Request, res: Response) => {
+    addDeprecationHeaders(res);
+    const tid = traceId(req);
+    const start = Date.now();
+    try {
+      const capReq = buildCapabilityRequest(req, {});
+      const outcome = await lendingService.getMarkets(capReq);
+      res.status(200).json(
+        buildSuccess({
+          data: outcome.data,
+          provider: outcome.provider,
+          traceId: tid,
+          latencyMs: Date.now() - start,
+        }),
+      );
+    } catch (err) {
+      wrapError(err, tid, res);
+    }
+  });
+
+  /**
+   * GET /v1/capability/lend/legacy/position/:address
+   */
+  router.get("/lend/legacy/position/:address", async (req: Request, res: Response) => {
+    addDeprecationHeaders(res);
+    const tid = traceId(req);
+    const start = Date.now();
+    try {
+      const { address } = req.params;
+      if (!validateAddress(address)) {
+        throw CapabilityError.validation({ capability: "lending", message: "Invalid wallet address" });
+      }
+      const capReq = buildCapabilityRequest(req, {}, address);
+      const outcome = await lendingService.getUserPosition(capReq);
+      res.status(200).json(
+        buildSuccess({
+          data: outcome.data,
+          provider: outcome.provider,
+          traceId: tid,
+          latencyMs: Date.now() - start,
+        }),
+      );
+    } catch (err) {
+      wrapError(err, tid, res);
+    }
+  });
+
+  return router;
+}

--- a/lending-service/tsconfig.json
+++ b/lending-service/tsconfig.json
@@ -12,7 +12,6 @@
     "types": ["node"],
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
-    "noImplicitAny": false,
     "baseUrl": "./",
     "paths": {
       "@panorama/capability": ["../shared/capability/index.ts"],

--- a/lending-service/tsconfig.json
+++ b/lending-service/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "outDir": "./dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "lib": ["es2020"],
+    "types": ["node"],
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "noImplicitAny": false,
+    "baseUrl": "./",
+    "paths": {
+      "@panorama/capability": ["../shared/capability/index.ts"],
+      "@panorama/capability/*": ["../shared/capability/*"]
+    }
+  },
+  "include": ["src/**/*"],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "../shared/capability/node_modules",
+    "../shared/capability/__tests__",
+    "../shared/capability/chains/__tests__",
+    "../shared/capability/http/__tests__"
+  ]
+}


### PR DESCRIPTION
## Card
DCA/Automation Capability refactor — Marcos (txrmarcos)

## Mudanças
- `dca-service/src/domain/ports/dca.provider.port.ts` — `IDCAProvider extends ICapabilityProvider` com contrato completo de automation (createAccount, getAccount, getUserAccounts, createStrategy, getStrategies, toggleStrategy, deleteStrategy, getHistory, signAndExecute, validatePermissions, withdraw, supportsRoute, healthCheck)
- `dca-service/src/infrastructure/adapters/erc4337.dca.adapter.ts` — wraps DCAService / SmartAccountService / TransactionService; session keys nunca retornam ao caller (invariante documentada no código)
- `dca-service/src/application/services/dca.capability.service.ts` — facade com ProviderRegistry, ChainAssetPriorityPolicy, idempotency Redis 24h, ownership validation por operação
- `dca-service/src/infrastructure/http/routes/capability.router.ts` — 11 endpoints `/v1/capability/dca/*` + `_discovery`; shims legados `/dca/*` e `/transaction/*` com Deprecation + Sunset headers
- `dca-service/src/infrastructure/di/container.ts` — DI singleton (registry + policy + service)
- `dca-service/src/infrastructure/redis/redis.client.ts` — lazy Redis client para idempotency store
- `dca-service/tsconfig.json` — path mapping `@panorama/capability` (alinha com liquid-swap-service)
- `dca-service/src/index.ts` — monta `/v1/capability/*` antes das rotas legadas

## DoD
- [x] `tsc --noEmit` passa sem erros
- [x] Idempotency: mesmo `x-idempotency-key` retorna resposta cacheada (Redis 24h)
- [x] Session keys: nenhum campo de session key no response envelope (invariante verificada no adapter)
- [x] Rotas legadas funcionam com headers `Deprecation` + `Sunset`
- [x] `GET /v1/capability/_discovery` retorna provider erc4337-dca com health
- [x] Ownership: usuário só acessa seus próprios recursos (validação na camada application)

## Novos endpoints
```
POST   /v1/capability/dca/account
GET    /v1/capability/dca/account/:address
GET    /v1/capability/dca/accounts/:userId
POST   /v1/capability/dca/strategy
GET    /v1/capability/dca/strategies/:accountId
PATCH  /v1/capability/dca/strategy/:id/toggle
DELETE /v1/capability/dca/strategy/:id
GET    /v1/capability/dca/history/:accountId
POST   /v1/capability/dca/execute
POST   /v1/capability/dca/validate
POST   /v1/capability/dca/withdraw
GET    /v1/capability/_discovery
```

## Dependência
Base: `feat/capability-refactor` (shared/capability disponível)
Merge target final: `develop` (após PR #283 mergeado)

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Maestri sprint — Marcos/txrmarcos)