### PR TITLE
fix: remove duplicate database gateway compose service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -338,28 +338,6 @@ services:
         condition: service_healthy
     restart: always
 
-  database_gateway:
-    build:
-      context: ./database
-      dockerfile: Dockerfile
-    container_name: panorama-database-gateway
-    ports:
-      - "${DATABASE_GATEWAY_PORT:-8080}:8080"
-    environment:
-      - DATABASE_URL=postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@engine_postgres:5432/panorama_db?schema=public
-      - PORT=8080
-      - LOG_LEVEL=${LOG_LEVEL:-info}
-      - JWT_SECRET=${JWT_SECRET:-changeme}
-    env_file:
-      - .env
-    command: sh -c "npx prisma migrate deploy && node dist/apps/gateway/src/main.js"
-    depends_on:
-      engine_postgres:
-        condition: service_healthy
-      engine_postgres_bootstrap:
-        condition: service_completed_successfully
-    restart: always
-
   execution_service:
     build:
       context: ../panoramablock-execution-layer/backend


### PR DESCRIPTION
## Summary

Removes the obsolete duplicate `database_gateway` service definition from the root `docker-compose.yml`.

The duplicate YAML mapping prevented Docker Compose from parsing the root Compose file:

`mapping key "database_gateway" already defined`

The retained definition is the newer database gateway configuration using `panorama_data_gateway`, the database gateway-specific JWT configuration, and the current migration/start commands.

## Verification

- Exactly one `database_gateway` service remains
- `docker compose config --no-interpolate`: passed
- `git diff --check`: passed
- Working tree clean

This change removes only the obsolete duplicate service block and does not modify the retained database gateway configuration.