### PR TITLE
fix: correct execution service compose context

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -340,7 +340,7 @@ services:
 
   execution_service:
     build:
-      context: ../panoramablock-execution-layer/backend
+      context: ../execution-layer/backend
       dockerfile: Dockerfile
     container_name: panorama-execution-service
     ports:


### PR DESCRIPTION
## Summary

Corrects the root Docker Compose build context for `execution_service`.

The Compose configuration referenced the obsolete local repository path:

`../panoramablock-execution-layer/backend`

The execution layer repository is `Panorama-Block/execution-layer`, and the current local repository layout places its backend at:

`../execution-layer/backend`

The existing path therefore prevented Docker Compose from locating the execution service build context.

## Verification

- `../execution-layer/backend` exists
- `../execution-layer/backend/Dockerfile` exists
- Execution service listens on port `3010`, matching the existing Compose configuration
- `docker compose config --no-interpolate`: passed
- Resolved Compose build context points to `execution-layer/backend`
- `git diff --check`: passed

This change modifies only the execution service build-context path.