### PR TITLE
ci: verify private auth container app deployment

### DIFF
--- a/.github/workflows/deploy-auth.yml
+++ b/.github/workflows/deploy-auth.yml
@@ -83,28 +83,54 @@ jobs:
           echo "Latest revision did not become ready in time."
           exit 1
 
-      - name: Smoke test health endpoint
+      - name: Verify deployed auth service
         run: |
           set -euo pipefail
-          FQDN="$(az containerapp show --name "$APP_NAME" --resource-group "$RG" --query properties.configuration.ingress.fqdn -o tsv)"
-          if [ -z "${FQDN:-}" ]; then
-            echo "Could not resolve ${APP_NAME} FQDN"
+
+          APP_STATE="$(az containerapp show \
+            --name "$APP_NAME" \
+            --resource-group "$RG" \
+            --query properties.runningStatus \
+            -o tsv)"
+
+          LATEST_REVISION="$(az containerapp show \
+            --name "$APP_NAME" \
+            --resource-group "$RG" \
+            --query properties.latestRevisionName \
+            -o tsv)"
+
+          READY_REVISION="$(az containerapp show \
+            --name "$APP_NAME" \
+            --resource-group "$RG" \
+            --query properties.latestReadyRevisionName \
+            -o tsv)"
+
+          echo "APP_STATE=${APP_STATE}"
+          echo "LATEST_REVISION=${LATEST_REVISION}"
+          echo "READY_REVISION=${READY_REVISION}"
+
+          if [ "$APP_STATE" != "Running" ]; then
+            echo "Container App is not running."
             exit 1
           fi
 
-          URL="https://${FQDN}/health"
-          for attempt in 1 2 3 4 5; do
-            status="$(curl -sS -L --max-time 30 -o /tmp/health_body.txt -w '%{http_code}' "$URL" || true)"
-            echo "HEALTH_STATUS=${status}"
-            cat /tmp/health_body.txt || true
+          if [ -z "$LATEST_REVISION" ] || [ "$LATEST_REVISION" != "$READY_REVISION" ]; then
+            echo "Latest revision is not ready."
+            exit 1
+          fi
 
-            if [ "$status" = "200" ]; then
-              echo "Health smoke test passed."
-              exit 0
-            fi
+          REPLICAS="$(az containerapp replica list \
+            --name "$APP_NAME" \
+            --resource-group "$RG" \
+            --revision "$LATEST_REVISION" \
+            --query 'length(@)' \
+            -o tsv)"
 
-            sleep 15
-          done
+          echo "REPLICA_COUNT=${REPLICAS}"
 
-          echo "Health smoke test failed."
-          exit 1
+          if [ "${REPLICAS:-0}" -lt 1 ]; then
+            echo "No running replica found for latest revision."
+            exit 1
+          fi
+
+          echo "Deployment verification passed."


### PR DESCRIPTION
Fixes the auth deployment workflow for the Azure Container App's internal-only ingress. Replaces the unreachable external /health curl with Azure control-plane verification of running state, ready revision, and replica availability.